### PR TITLE
Add logic to generate self-signed certificates

### DIFF
--- a/packages/k8s/package-lock.json
+++ b/packages/k8s/package-lock.json
@@ -18,12 +18,14 @@
         "google-protobuf": "^3.21.4",
         "hooklib": "file:../hooklib",
         "js-yaml": "^4.1.0",
+        "node-forge": "^1.3.1",
         "shlex": "^2.1.2",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.23",
+        "@types/node-forge": "^1.3.11",
         "@vercel/ncc": "^0.33.4",
         "jest": "^29.7.0",
         "ts-jest": "^29.3.4",
@@ -3735,6 +3737,16 @@
         "form-data": "^4.0.0"
       }
     },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "dev": true,
@@ -6592,6 +6604,15 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {

--- a/packages/k8s/package.json
+++ b/packages/k8s/package.json
@@ -4,10 +4,8 @@
   "description": "",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mkdir -p ./src/hooks/proto && cp ../proto/script_executor.proto ./src/hooks/proto/script_executor.proto && jest --runInBand",
-    "posttest": "rm -rf ./src/hooks/proto",
+    "test": "jest --runInBand",
     "build": "tsc && npx ncc build",
-    "postbuild": "mkdir -p ./dist/proto && cp ../proto/script_executor.proto ./dist/proto/script_executor.proto",
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts"
@@ -24,12 +22,14 @@
     "google-protobuf": "^3.21.4",
     "hooklib": "file:../hooklib",
     "js-yaml": "^4.1.0",
+    "node-forge": "^1.3.1",
     "shlex": "^2.1.2",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.23",
+    "@types/node-forge": "^1.3.11",
     "@vercel/ncc": "^0.33.4",
     "jest": "^29.7.0",
     "ts-jest": "^29.3.4",

--- a/packages/k8s/src/k8s/certs.ts
+++ b/packages/k8s/src/k8s/certs.ts
@@ -108,7 +108,6 @@ export function generateCert(
   )
   cert.setIssuer(attributes.concat([{ name: 'commonName', value: issuerName }]))
 
-  // Needed because the GRPC client and server will use localhost address.
   cert.setExtensions([
     {
       name: 'basicConstraints',

--- a/packages/k8s/src/k8s/certs.ts
+++ b/packages/k8s/src/k8s/certs.ts
@@ -9,7 +9,6 @@ interface CertAndKeyPairs {
 interface CertAndKeys {
   cert: string
   privateKey: string
-  publicKey: string
 }
 
 export interface MTLSCertAndPrivateKey {
@@ -57,36 +56,25 @@ export function generateCerts(): MTLSCertAndPrivateKey {
   )
 
   const caPem = forge.pki.certificateToPem(caKeyAndCert.cert)
-  const caPublicKeyPem = forge.pki.publicKeyToPem(
-    caKeyAndCert.keyPairs.publicKey
-  )
   const serverPem = forge.pki.certificateToPem(serverKeyAndCert.cert)
   const serverKeyPem = forge.pki.privateKeyToPem(
     serverKeyAndCert.keyPairs.privateKey
-  )
-  const serverPublicKeyPem = forge.pki.publicKeyToPem(
-    serverKeyAndCert.keyPairs.publicKey
   )
   const clientPem = forge.pki.certificateToPem(clientKeyAndCert.cert)
   const clientKeyPem = forge.pki.privateKeyToPem(
     clientKeyAndCert.keyPairs.privateKey
   )
-  const clientPublicKeyPem = forge.pki.publicKeyToPem(
-    clientKeyAndCert.keyPairs.publicKey
-  )
 
   // We do not need to store to private key for the self-signed CA certificate.
   return {
-    caCertAndkey: { cert: caPem, privateKey: '', publicKey: caPublicKeyPem },
+    caCertAndkey: { cert: caPem, privateKey: '' },
     serverCertAndKey: {
       cert: serverPem,
-      privateKey: serverKeyPem,
-      publicKey: serverPublicKeyPem
+      privateKey: serverKeyPem
     },
     clientCertAndKey: {
       cert: clientPem,
-      privateKey: clientKeyPem,
-      publicKey: clientPublicKeyPem
+      privateKey: clientKeyPem
     }
   }
 }
@@ -134,6 +122,11 @@ export function generateCert(
       keyEncipherment: true,
       dataEncipherment: true
     },
+    {
+      name: 'extKeyUsage',
+      serverAuth: true,
+      clientAuth: true
+    },
     // Needed because the GRPC client and server will use localhost address.
     {
       name: 'subjectAltName',
@@ -144,20 +137,6 @@ export function generateCert(
       ]
     }
   ])
-
-  if (subjectName === CertCommonName.SERVER) {
-    cert.extensions.push({
-      name: 'extKeyUsage',
-      serverAuth: true
-    })
-  }
-
-  if (subjectName === CertCommonName.CLIENT) {
-    cert.extensions.push({
-      name: 'extKeyUsage',
-      clientAuth: true
-    })
-  }
 
   return {
     keyPairs,

--- a/packages/k8s/src/k8s/certs.ts
+++ b/packages/k8s/src/k8s/certs.ts
@@ -1,0 +1,166 @@
+import * as forge from 'node-forge'
+import * as crypto from 'crypto'
+
+interface CertAndKeyPairs {
+  cert: forge.pki.Certificate
+  keyPairs: forge.pki.rsa.KeyPair
+}
+
+interface CertAndKeys {
+  cert: string
+  privateKey: string
+  publicKey: string
+}
+
+export interface MTLSCertAndPrivateKey {
+  caCertAndkey: CertAndKeys
+  serverCertAndKey: CertAndKeys
+  clientCertAndKey: CertAndKeys
+}
+
+export enum CertCommonName {
+  ROOT = 'root',
+  SERVER = 'server',
+  CLIENT = 'client'
+}
+
+export function generateCerts(): MTLSCertAndPrivateKey {
+  const caKeyAndCert = generateCert(7, CertCommonName.ROOT, CertCommonName.ROOT)
+
+  // Self-sign CA certificate.
+  caKeyAndCert.cert.sign(
+    caKeyAndCert.keyPairs.privateKey,
+    forge.md.sha256.create()
+  )
+
+  // Server certificate.
+  const serverKeyAndCert = generateCert(
+    7,
+    CertCommonName.ROOT,
+    CertCommonName.SERVER
+  )
+
+  serverKeyAndCert.cert.sign(
+    caKeyAndCert.keyPairs.privateKey,
+    forge.md.sha256.create()
+  )
+
+  // Client certificate.
+  const clientKeyAndCert = generateCert(
+    7,
+    CertCommonName.ROOT,
+    CertCommonName.CLIENT
+  )
+  clientKeyAndCert.cert.sign(
+    caKeyAndCert.keyPairs.privateKey,
+    forge.md.sha256.create()
+  )
+
+  const caPem = forge.pki.certificateToPem(caKeyAndCert.cert)
+  const caPublicKeyPem = forge.pki.publicKeyToPem(
+    caKeyAndCert.keyPairs.publicKey
+  )
+  const serverPem = forge.pki.certificateToPem(serverKeyAndCert.cert)
+  const serverKeyPem = forge.pki.privateKeyToPem(
+    serverKeyAndCert.keyPairs.privateKey
+  )
+  const serverPublicKeyPem = forge.pki.publicKeyToPem(
+    serverKeyAndCert.keyPairs.publicKey
+  )
+  const clientPem = forge.pki.certificateToPem(clientKeyAndCert.cert)
+  const clientKeyPem = forge.pki.privateKeyToPem(
+    clientKeyAndCert.keyPairs.privateKey
+  )
+  const clientPublicKeyPem = forge.pki.publicKeyToPem(
+    clientKeyAndCert.keyPairs.publicKey
+  )
+
+  // We do not need to store to private key for the self-signed CA certificate.
+  return {
+    caCertAndkey: { cert: caPem, privateKey: '', publicKey: caPublicKeyPem },
+    serverCertAndKey: {
+      cert: serverPem,
+      privateKey: serverKeyPem,
+      publicKey: serverPublicKeyPem
+    },
+    clientCertAndKey: {
+      cert: clientPem,
+      privateKey: clientKeyPem,
+      publicKey: clientPublicKeyPem
+    }
+  }
+}
+
+export function generateCert(
+  validityDays: number,
+  issuerName: CertCommonName,
+  subjectName: CertCommonName
+): CertAndKeyPairs {
+  const keyPairs = forge.pki.rsa.generateKeyPair(2048)
+  const cert = forge.pki.createCertificate()
+  cert.publicKey = keyPairs.publicKey
+
+  cert.serialNumber = crypto.randomBytes(19).toString('hex')
+  cert.validity.notBefore = new Date()
+  cert.validity.notAfter = new Date(
+    new Date().getTime() + 1000 * 60 * 60 * 24 * (validityDays ?? 1)
+  )
+  const attributes: forge.pki.CertificateField[] = [
+    {
+      name: 'countryName',
+      value: 'US'
+    },
+    {
+      shortName: 'ST',
+      value: 'California'
+    }
+  ]
+  cert.setSubject(
+    attributes.concat([{ name: 'commonName', value: subjectName }])
+  )
+  cert.setIssuer(attributes.concat([{ name: 'commonName', value: issuerName }]))
+
+  // Needed because the GRPC client and server will use localhost address.
+  cert.setExtensions([
+    {
+      name: 'basicConstraints',
+      cA: subjectName === CertCommonName.ROOT ? true : false
+    },
+    {
+      name: 'keyUsage',
+      keyCertSign: true,
+      digitalSignature: true,
+      nonRepudiation: true,
+      keyEncipherment: true,
+      dataEncipherment: true
+    },
+    // Needed because the GRPC client and server will use localhost address.
+    {
+      name: 'subjectAltName',
+      altNames: [
+        { type: 2, value: 'localhost' }, // DNS name
+        { type: 7, ip: '127.0.0.1' }, // IP address
+        { type: 7, ip: '0.0.0.0' } // IP address
+      ]
+    }
+  ])
+
+  if (subjectName === CertCommonName.SERVER) {
+    cert.extensions.push({
+      name: 'extKeyUsage',
+      serverAuth: true
+    })
+  }
+
+  if (subjectName === CertCommonName.CLIENT) {
+    cert.extensions.push({
+      name: 'extKeyUsage',
+      clientAuth: true
+    })
+  }
+
+  return {
+    keyPairs,
+    cert
+  }
+}

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -13,7 +13,7 @@ import {
 } from '../src/k8s/utils'
 import * as k8s from '@kubernetes/client-node'
 import { TestHelper } from './test-setup'
-import { CertCommonName, generateCert } from '../src/k8s/certs'
+import { CertCommonName, generateCert, generateCerts } from '../src/k8s/certs'
 
 let testHelper: TestHelper
 
@@ -636,5 +636,23 @@ describe.only('certs', () => {
         })
       ])
     )
+  })
+
+  it('should generate signed server and client certs', () => {
+    const certs = generateCerts()
+    expect(certs.caCertAndkey.cert).toBeTruthy()
+    expect(certs.caCertAndkey.privateKey).not.toBeTruthy()
+    expect(certs.serverCertAndKey.cert).toBeTruthy()
+    expect(certs.serverCertAndKey.privateKey).toBeTruthy()
+    expect(certs.clientCertAndKey.cert).toBeTruthy()
+    expect(certs.clientCertAndKey.privateKey).toBeTruthy()
+
+    const caCert = forge.pki.certificateFromPem(certs.caCertAndkey.cert)
+    expect(
+      caCert.verify(forge.pki.certificateFromPem(certs.serverCertAndKey.cert))
+    ).toBeTruthy()
+    expect(
+      caCert.verify(forge.pki.certificateFromPem(certs.clientCertAndKey.cert))
+    ).toBeTruthy()
   })
 })

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -553,7 +553,7 @@ spec:
   })
 })
 
-describe.only('certs', () => {
+describe('certs', () => {
   it('should create self-signed CA', () => {
     const caCert = generateCert(7, CertCommonName.ROOT, CertCommonName.ROOT)
     expect(caCert.cert.subject.attributes).toEqual(

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -1,4 +1,5 @@
 ﻿import * as fs from 'fs'
+import * as forge from 'node-forge'
 import { containerPorts, POD_VOLUME_NAME } from '../src/k8s'
 import {
   containerVolumes,
@@ -12,6 +13,7 @@ import {
 } from '../src/k8s/utils'
 import * as k8s from '@kubernetes/client-node'
 import { TestHelper } from './test-setup'
+import { CertCommonName, generateCert } from '../src/k8s/certs'
 
 let testHelper: TestHelper
 
@@ -548,5 +550,91 @@ spec:
     mergePodSpecWithOptions(base, from)
 
     expect(base).toStrictEqual(expected)
+  })
+})
+
+describe.only('certs', () => {
+  it('should create self-signed CA', () => {
+    const caCert = generateCert(7, CertCommonName.ROOT, CertCommonName.ROOT)
+    expect(caCert.cert.subject.attributes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'commonName',
+          value: CertCommonName.ROOT
+        })
+      ])
+    )
+    expect(caCert.cert.issuer.attributes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'commonName',
+          value: CertCommonName.ROOT
+        })
+      ])
+    )
+    expect(caCert.cert.extensions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'basicConstraints',
+          cA: true
+        })
+      ])
+    )
+  })
+
+  it('should create server cert', () => {
+    const caCert = generateCert(7, CertCommonName.ROOT, CertCommonName.SERVER)
+    expect(caCert.cert.subject.attributes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'commonName',
+          value: CertCommonName.SERVER
+        })
+      ])
+    )
+    expect(caCert.cert.issuer.attributes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'commonName',
+          value: CertCommonName.ROOT
+        })
+      ])
+    )
+    expect(caCert.cert.extensions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'basicConstraints',
+          cA: false
+        })
+      ])
+    )
+  })
+
+  it('should create client cert', () => {
+    const caCert = generateCert(7, CertCommonName.ROOT, CertCommonName.CLIENT)
+    expect(caCert.cert.subject.attributes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'commonName',
+          value: CertCommonName.CLIENT
+        })
+      ])
+    )
+    expect(caCert.cert.issuer.attributes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'commonName',
+          value: CertCommonName.ROOT
+        })
+      ])
+    )
+    expect(caCert.cert.extensions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'basicConstraints',
+          cA: false
+        })
+      ])
+    )
   })
 })


### PR DESCRIPTION
Using `node-forge` to generate a self-signed CA, a signed client and server certificates with the self-signed CA. This will enable us to use mutual TLS because both the client and server certs are signed with the same self-signed CA. This is to prevent man in the middle attack.