### PR TITLE
Make script executor store the script command and execute it

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,6 @@ dist/
 lib/
 proto/
 script_executor.ts
+**/script_executor/**
 node_modules/
 **/tests/**

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -32,10 +32,7 @@ export async function runScriptStep(
   try {
     if (useScriptExecutor()) {
       core.info('using script executor')
-      const command = fixArgs([args.entryPoint, ...args.entryPointArgs]).join(
-        ' '
-      )
-      core.debug(`exec command ${command}`)
+      const command = fs.readFileSync(runnerPath)
 
       const status = await getPodStatus(podName)
       if (status?.phase === 'Succeeded') {
@@ -48,7 +45,7 @@ export async function runScriptStep(
       const rootCertClientAndKey = await getRootCertClientCertAndKey()
       core.debug('successfully retrieved root cert, client and key')
       await runScriptByGrpc(
-        command,
+        command.toString(),
         rootCertClientAndKey.caCertAndkey.cert,
         rootCertClientAndKey.clientCertAndKey.cert,
         rootCertClientAndKey.clientCertAndKey.privateKey,

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -6,17 +6,66 @@ import { RunScriptStepArgs } from 'hooklib'
 import { execPodStep, getPodStatus, getRootCertClientCertAndKey } from '../k8s'
 import {
   fixArgs,
+  getEntryPointScriptContent,
   runScriptByGrpc,
   useScriptExecutor,
   writeEntryPointScript
 } from '../k8s/utils'
 import { GRPC_SCRIPT_EXECUTOR_PORT, JOB_CONTAINER_NAME } from './constants'
 
+async function runScriptStepWithGRPC(
+  args: RunScriptStepArgs,
+  state
+): Promise<void> {
+  const { entryPoint, entryPointArgs, environmentVariables } = args
+  const scriptContent = getEntryPointScriptContent(
+    args.workingDirectory,
+    entryPoint,
+    entryPointArgs,
+    args.prependPath,
+    environmentVariables
+  )
+
+  try {
+    const podName = state.jobPod
+    core.info('using script executor')
+
+    const status = await getPodStatus(podName)
+    if (status?.phase === 'Succeeded') {
+      throw new Error(`Failed to get pod ${podName} status`)
+    }
+    if (status?.podIP === undefined) {
+      throw new Error(`Failed to get pod ${podName} IP`)
+    }
+
+    const rootCertClientAndKey = await getRootCertClientCertAndKey()
+    core.debug('successfully retrieved root cert, client and key')
+    await runScriptByGrpc(
+      scriptContent,
+      rootCertClientAndKey.caCertAndkey.cert,
+      rootCertClientAndKey.clientCertAndKey.cert,
+      rootCertClientAndKey.clientCertAndKey.privateKey,
+      status.podIP,
+      GRPC_SCRIPT_EXECUTOR_PORT
+    )
+  } catch (err) {
+    core.debug(
+      `Run script Executor through GRPC failed: ${JSON.stringify(err)}`
+    )
+    const message = (err as any)?.response?.body?.message || err
+    throw new Error(`failed to run script step: ${message}`)
+  }
+}
+
 export async function runScriptStep(
   args: RunScriptStepArgs,
   state,
   responseFile
 ): Promise<void> {
+  if (useScriptExecutor()) {
+    return runScriptStepWithGRPC(args, state)
+  }
+
   const { entryPoint, entryPointArgs, environmentVariables } = args
   const { containerPath, runnerPath } = writeEntryPointScript(
     args.workingDirectory,
@@ -30,36 +79,12 @@ export async function runScriptStep(
   args.entryPointArgs = ['-e', containerPath]
   const podName = state.jobPod
   try {
-    if (useScriptExecutor()) {
-      core.info('using script executor')
-      const command = fs.readFileSync(runnerPath)
-
-      const status = await getPodStatus(podName)
-      if (status?.phase === 'Succeeded') {
-        throw new Error(`Failed to get pod ${podName} status`)
-      }
-      if (status?.podIP === undefined) {
-        throw new Error(`Failed to get pod ${podName} IP`)
-      }
-
-      const rootCertClientAndKey = await getRootCertClientCertAndKey()
-      core.debug('successfully retrieved root cert, client and key')
-      await runScriptByGrpc(
-        command.toString(),
-        rootCertClientAndKey.caCertAndkey.cert,
-        rootCertClientAndKey.clientCertAndKey.cert,
-        rootCertClientAndKey.clientCertAndKey.privateKey,
-        status.podIP,
-        GRPC_SCRIPT_EXECUTOR_PORT
-      )
-    } else {
-      core.info('using exec pod step')
-      await execPodStep(
-        [args.entryPoint, ...args.entryPointArgs],
-        podName,
-        JOB_CONTAINER_NAME
-      )
-    }
+    core.info('using exec pod step')
+    await execPodStep(
+      [args.entryPoint, ...args.entryPointArgs],
+      podName,
+      JOB_CONTAINER_NAME
+    )
   } catch (err) {
     core.debug(`execPodStep failed: ${JSON.stringify(err)}`)
     const message = (err as any)?.response?.body?.message || err

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -118,13 +118,13 @@ export function containerVolumes(
   return mounts
 }
 
-export function writeEntryPointScript(
+export function getEntryPointScriptContent(
   workingDirectory: string,
   entryPoint: string,
   entryPointArgs?: string[],
   prependPath?: string[],
   environmentVariables?: { [key: string]: string }
-): { containerPath: string; runnerPath: string } {
+): string {
   let exportPath = ''
   if (prependPath?.length) {
     // TODO: remove compatibility with typeof prependPath === 'string' as we bump to next major version, the hooks will lose PrependPath compat with runners 2.293.0 and older
@@ -165,6 +165,23 @@ exec ${environmentPrefix} ${entryPoint} ${
     entryPointArgs?.length ? entryPointArgs.join(' ') : ''
   }
 `
+  return content
+}
+
+export function writeEntryPointScript(
+  workingDirectory: string,
+  entryPoint: string,
+  entryPointArgs?: string[],
+  prependPath?: string[],
+  environmentVariables?: { [key: string]: string }
+): { containerPath: string; runnerPath: string } {
+  const content = getEntryPointScriptContent(
+    workingDirectory,
+    entryPoint,
+    entryPointArgs,
+    prependPath,
+    environmentVariables
+  )
   const filename = `${uuidv4()}.sh`
   const entryPointPath = `${process.env.RUNNER_TEMP}/${filename}`
   fs.writeFileSync(entryPointPath, content)

--- a/packages/script_executor/package-lock.json
+++ b/packages/script_executor/package-lock.json
@@ -1,18 +1,20 @@
 {
     "name": "ml-velocity-script-executor",
-    "version": "0.1.0",
+    "version": "0.1.2-alpha.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ml-velocity-script-executor",
-            "version": "0.1.0",
+            "version": "0.1.2-alpha.11",
             "dependencies": {
                 "@grpc/grpc-js": "^1.12.5",
                 "@grpc/proto-loader": "^0.7.13",
-                "google-protobuf": "^3.21.4"
+                "google-protobuf": "^3.21.4",
+                "tmp": "^0.2.3"
             },
             "devDependencies": {
+                "@types/tmp": "^0.2.6",
                 "@vercel/ncc": "^0.38.3",
                 "prettier": "^3.5.3",
                 "typescript": "^5.0.4"
@@ -131,6 +133,13 @@
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
+        },
+        "node_modules/@types/tmp": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+            "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@vercel/ncc": {
             "version": "0.38.3",
@@ -322,6 +331,15 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/tmp": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.14"
             }
         },
         "node_modules/typescript": {

--- a/packages/script_executor/package.json
+++ b/packages/script_executor/package.json
@@ -1,10 +1,11 @@
 {
     "name": "ml-velocity-script-executor",
-    "version": "0.1.2-alpha.11",
+    "version": "0.1.2-alpha.15.6",
     "dependencies": {
         "@grpc/grpc-js": "^1.12.5",
         "@grpc/proto-loader": "^0.7.13",
-        "google-protobuf": "^3.21.4"
+        "google-protobuf": "^3.21.4",
+        "tmp": "^0.2.3"
     },
     "type": "commonjs",
     "repository": {
@@ -21,6 +22,7 @@
         "lint": "eslint src/**/*.ts"
     },
     "devDependencies": {
+        "@types/tmp": "^0.2.6",
         "@vercel/ncc": "^0.38.3",
         "prettier": "^3.5.3",
         "typescript": "^5.0.4"


### PR DESCRIPTION
Currently we are just running sh -e ${bash script location} in the script executor. This change will writes the script command to a temporary file location on the server and execute that instead. This will remove the need to share a mounted volume between the runner node and the workload node or having to copy over the bash file with the script content.