### PR TITLE
Add headless service to target the runner workflow

### DIFF
--- a/packages/k8s/src/hooks/cleanup-job.ts
+++ b/packages/k8s/src/hooks/cleanup-job.ts
@@ -1,5 +1,5 @@
-import { prunePods, pruneSecrets } from '../k8s'
+import { prunePods, pruneSecrets, pruneServices } from '../k8s'
 
 export async function cleanupJob(): Promise<void> {
-  await Promise.all([prunePods(), pruneSecrets()])
+  await Promise.all([prunePods(), pruneSecrets(), pruneServices()])
 }

--- a/packages/k8s/src/hooks/constants.ts
+++ b/packages/k8s/src/hooks/constants.ts
@@ -17,6 +17,13 @@ export function getJobPodName(): string {
   )}-workflow`
 }
 
+export function getServiceName(): string {
+  return `${getRunnerPodName().substring(
+    0,
+    MAX_POD_NAME_LENGTH - '-service'.length
+  )}-service`  
+}
+
 export function getStepPodName(): string {
   return `${getRunnerPodName().substring(
     0,

--- a/packages/k8s/src/hooks/constants.ts
+++ b/packages/k8s/src/hooks/constants.ts
@@ -21,7 +21,7 @@ export function getServiceName(): string {
   return `${getRunnerPodName().substring(
     0,
     MAX_POD_NAME_LENGTH - '-service'.length
-  )}-service`  
+  )}-service`
 }
 
 export function getStepPodName(): string {

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -14,7 +14,8 @@ import {
   isPodContainerAlpine,
   prunePods,
   waitForPodPhases,
-  getPrepareJobTimeoutSeconds
+  getPrepareJobTimeoutSeconds,
+  createHeadlessService
 } from '../k8s'
 import {
   containerVolumes,
@@ -122,6 +123,12 @@ export async function prepareJob(
     throw new Error(`failed to determine if the pod is alpine: ${message}`)
   }
   core.debug(`Setting isAlpine to ${isAlpine}`)
+
+  if (useScriptExecutor()) {
+    core.debug(`Creating headless service`)
+    await createHeadlessService()
+  }
+
   generateResponseFile(responseFile, args, createdPod, isAlpine)
 }
 

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -34,7 +34,7 @@ async function runScriptStepWithGRPC(
     core.info('using script executor')
 
     const serviceName = getServiceName()
-    core.info('using service name ' + serviceName)
+    core.debug('using service name ' + serviceName)
 
     const rootCertClientAndKey = await getRootCertClientCertAndKey()
     core.debug('successfully retrieved root cert, client and key')

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -11,7 +11,7 @@ import {
   useScriptExecutor,
   writeEntryPointScript
 } from '../k8s/utils'
-import { GRPC_SCRIPT_EXECUTOR_PORT, JOB_CONTAINER_NAME } from './constants'
+import { getServiceName, GRPC_SCRIPT_EXECUTOR_PORT, JOB_CONTAINER_NAME } from './constants'
 
 async function runScriptStepWithGRPC(
   args: RunScriptStepArgs,
@@ -30,6 +30,8 @@ async function runScriptStepWithGRPC(
     const podName = state.jobPod
     core.info('using script executor')
 
+    const serviceName = getServiceName()
+    /*
     const status = await getPodStatus(podName)
     if (status?.phase === 'Succeeded') {
       throw new Error(`Failed to get pod ${podName} status`)
@@ -37,6 +39,8 @@ async function runScriptStepWithGRPC(
     if (status?.podIP === undefined) {
       throw new Error(`Failed to get pod ${podName} IP`)
     }
+      */
+    core.info('using service name ' + serviceName)
 
     const rootCertClientAndKey = await getRootCertClientCertAndKey()
     core.debug('successfully retrieved root cert, client and key')
@@ -45,7 +49,7 @@ async function runScriptStepWithGRPC(
       rootCertClientAndKey.caCertAndkey.cert,
       rootCertClientAndKey.clientCertAndKey.cert,
       rootCertClientAndKey.clientCertAndKey.privateKey,
-      status.podIP,
+      serviceName,
       GRPC_SCRIPT_EXECUTOR_PORT
     )
   } catch (err) {

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -11,7 +11,11 @@ import {
   useScriptExecutor,
   writeEntryPointScript
 } from '../k8s/utils'
-import { getServiceName, GRPC_SCRIPT_EXECUTOR_PORT, JOB_CONTAINER_NAME } from './constants'
+import {
+  getServiceName,
+  GRPC_SCRIPT_EXECUTOR_PORT,
+  JOB_CONTAINER_NAME
+} from './constants'
 
 async function runScriptStepWithGRPC(
   args: RunScriptStepArgs,

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -3,9 +3,8 @@ import * as fs from 'fs'
 import * as core from '@actions/core'
 
 import { RunScriptStepArgs } from 'hooklib'
-import { execPodStep, getPodStatus, getRootCertClientCertAndKey } from '../k8s'
+import { execPodStep, getRootCertClientCertAndKey } from '../k8s'
 import {
-  fixArgs,
   getEntryPointScriptContent,
   runScriptByGrpc,
   useScriptExecutor,
@@ -35,15 +34,6 @@ async function runScriptStepWithGRPC(
     core.info('using script executor')
 
     const serviceName = getServiceName()
-    /*
-    const status = await getPodStatus(podName)
-    if (status?.phase === 'Succeeded') {
-      throw new Error(`Failed to get pod ${podName} status`)
-    }
-    if (status?.podIP === undefined) {
-      throw new Error(`Failed to get pod ${podName} IP`)
-    }
-      */
     core.info('using service name ' + serviceName)
 
     const rootCertClientAndKey = await getRootCertClientCertAndKey()

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -30,11 +30,10 @@ async function runScriptStepWithGRPC(
   )
 
   try {
-    const podName = state.jobPod
     core.info('using script executor')
 
     const serviceName = getServiceName()
-    core.debug('using service name ' + serviceName)
+    core.debug(`using service name ${serviceName}`)
 
     const rootCertClientAndKey = await getRootCertClientCertAndKey()
     core.debug('successfully retrieved root cert, client and key')

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -75,7 +75,8 @@ export async function createHeadlessService(): Promise<void> {
     namespace: namespace(),
     body: {
       metadata: {
-        name: getServiceName()
+        name: getServiceName(),
+        labels: { [instanceLabel.key]: instanceLabel.value }
       },
       spec: {
         selector: {
@@ -566,12 +567,14 @@ export async function prunePods(): Promise<void> {
 }
 
 export async function pruneServices(): Promise<void> {
-  core.debug("pruning services")
+  core.debug(
+    'pruning services with labels ' + new RunnerInstanceLabel().toString()
+  )
   const serviceList = await k8sApi.listNamespacedService({
     namespace: namespace(),
     labelSelector: new RunnerInstanceLabel().toString()
   })
-  core.debug("service list " + JSON.stringify(serviceList.items))
+  core.debug(`pruning ${serviceList.items.length} service(s)`)
   if (!serviceList.items.length) {
     return
   }
@@ -579,11 +582,12 @@ export async function pruneServices(): Promise<void> {
   try {
     await Promise.all(
       serviceList.items.map(
-        service => service.metadata?.name && deleteService(service.metadata.name)
+        service =>
+          service.metadata?.name && deleteService(service.metadata.name)
       )
-    )  
+    )
   } catch (error) {
-    core.debug("error pruning service " + error)
+    core.debug('error pruning service ' + error)
   }
 }
 

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -567,12 +567,11 @@ export async function prunePods(): Promise<void> {
 }
 
 export async function pruneServices(): Promise<void> {
-  core.debug(
-    'pruning services with labels ' + new RunnerInstanceLabel().toString()
-  )
+  const labelSelector = new RunnerInstanceLabel().toString()
+  core.debug(`pruning services with labels ${labelSelector}`)
   const serviceList = await k8sApi.listNamespacedService({
     namespace: namespace(),
-    labelSelector: new RunnerInstanceLabel().toString()
+    labelSelector
   })
   core.debug(`pruning ${serviceList.items.length} service(s)`)
   if (!serviceList.items.length) {
@@ -587,7 +586,7 @@ export async function pruneServices(): Promise<void> {
       )
     )
   } catch (error) {
-    core.debug('error pruning service ' + error)
+    core.debug(`error pruning service ${error}`)
   }
 }
 

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -566,19 +566,25 @@ export async function prunePods(): Promise<void> {
 }
 
 export async function pruneServices(): Promise<void> {
+  core.debug("pruning services")
   const serviceList = await k8sApi.listNamespacedService({
     namespace: namespace(),
     labelSelector: new RunnerInstanceLabel().toString()
   })
+  core.debug("service list " + JSON.stringify(serviceList.items))
   if (!serviceList.items.length) {
     return
   }
 
-  await Promise.all(
-    serviceList.items.map(
-      service => service.metadata?.name && deleteService(service.metadata.name)
-    )
-  )
+  try {
+    await Promise.all(
+      serviceList.items.map(
+        service => service.metadata?.name && deleteService(service.metadata.name)
+      )
+    )  
+  } catch (error) {
+    core.debug("error pruning service " + error)
+  }
 }
 
 export async function getPodStatus(

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -6,8 +6,10 @@ import {
   getJobPodName,
   getRunnerPodName,
   getSecretName,
+  getServiceName,
   getStepPodName,
   getVolumeClaimName,
+  GRPC_SCRIPT_EXECUTOR_PORT,
   RunnerInstanceLabel
 } from '../hooks/constants'
 import {
@@ -66,6 +68,30 @@ export const requiredPermissions = [
     subresource: ''
   }
 ]
+
+export async function createHeadlessService(): Promise<void> {
+  const instanceLabel = new RunnerInstanceLabel()
+  await k8sApi.createNamespacedService({
+    namespace: namespace(),
+    body: {
+      metadata: {
+        name: getServiceName()
+      },
+      spec: {
+        selector: {
+          [instanceLabel.key]: instanceLabel.value
+        },
+        ports: [
+          {
+            name: "grpc",
+            targetPort: GRPC_SCRIPT_EXECUTOR_PORT,
+            port: GRPC_SCRIPT_EXECUTOR_PORT
+          }
+        ]
+      }
+    }
+  })
+}
 
 export async function createPod(
   jobContainer?: k8s.V1Container,

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -83,7 +83,7 @@ export async function createHeadlessService(): Promise<void> {
         },
         ports: [
           {
-            name: "grpc",
+            name: 'grpc',
             targetPort: GRPC_SCRIPT_EXECUTOR_PORT,
             port: GRPC_SCRIPT_EXECUTOR_PORT
           }
@@ -296,6 +296,14 @@ export async function getContainerJobPodName(jobName: string): Promise<string> {
 export async function deletePod(podName: string): Promise<void> {
   await k8sApi.deleteNamespacedPod({
     name: podName,
+    namespace: namespace(),
+    gracePeriodSeconds: 0
+  })
+}
+
+export async function deleteService(serviceName: string): Promise<void> {
+  await k8sApi.deleteNamespacedService({
+    name: serviceName,
     namespace: namespace(),
     gracePeriodSeconds: 0
   })
@@ -554,6 +562,22 @@ export async function prunePods(): Promise<void> {
 
   await Promise.all(
     podList.items.map(pod => pod.metadata?.name && deletePod(pod.metadata.name))
+  )
+}
+
+export async function pruneServices(): Promise<void> {
+  const serviceList = await k8sApi.listNamespacedService({
+    namespace: namespace(),
+    labelSelector: new RunnerInstanceLabel().toString()
+  })
+  if (!serviceList.items.length) {
+    return
+  }
+
+  await Promise.all(
+    serviceList.items.map(
+      service => service.metadata?.name && deleteService(service.metadata.name)
+    )
   )
 }
 

--- a/packages/k8s/tests/test-setup.ts
+++ b/packages/k8s/tests/test-setup.ts
@@ -16,7 +16,7 @@ export class TestHelper {
   private podName: string
   constructor() {
     this.tempDirPath = `${__dirname}/_temp/runner`
-    this.podName = uuidv4().replace(/-/g, '')
+    this.podName = `p${uuidv4().replace(/-/g, '')}` // Needs to start with alphabetic character
   }
 
   public async initialize(): Promise<void> {


### PR DESCRIPTION
Each headless service will target a runner workflow (the service will be cleaned up after the job is done).
The hook will use the headless service to reach the pod instead of through the pod's IP.