### PR TITLE
Add retry logic for ECONNREFUSED error

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -15,9 +15,7 @@ import {
   prunePods,
   waitForPodPhases,
   getPrepareJobTimeoutSeconds,
-  createHeadlessService,
-  getPodStatus,
-  getHeadlessService
+  createHeadlessService
 } from '../k8s'
 import {
   containerVolumes,

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -15,7 +15,9 @@ import {
   prunePods,
   waitForPodPhases,
   getPrepareJobTimeoutSeconds,
-  createHeadlessService
+  createHeadlessService,
+  getPodStatus,
+  getHeadlessService
 } from '../k8s'
 import {
   containerVolumes,
@@ -125,8 +127,15 @@ export async function prepareJob(
   core.debug(`Setting isAlpine to ${isAlpine}`)
 
   if (useScriptExecutor()) {
+    const podStatus = await getPodStatus(createdPod.metadata.name)
+    core.debug('pod status ' + JSON.stringify(podStatus))
     core.debug(`Creating headless service`)
     await createHeadlessService()
+    const service = await getHeadlessService()
+    core.debug('headless service ' + JSON.stringify(service))
+    const anotherPodStatus = await getPodStatus(createdPod.metadata.name)
+    core.debug('pod status ' + JSON.stringify(anotherPodStatus))
+    // Wait for headless service to become available.
   }
 
   generateResponseFile(responseFile, args, createdPod, isAlpine)

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -127,15 +127,8 @@ export async function prepareJob(
   core.debug(`Setting isAlpine to ${isAlpine}`)
 
   if (useScriptExecutor()) {
-    const podStatus = await getPodStatus(createdPod.metadata.name)
-    core.debug('pod status ' + JSON.stringify(podStatus))
     core.debug(`Creating headless service`)
     await createHeadlessService()
-    const service = await getHeadlessService()
-    core.debug('headless service ' + JSON.stringify(service))
-    const anotherPodStatus = await getPodStatus(createdPod.metadata.name)
-    core.debug('pod status ' + JSON.stringify(anotherPodStatus))
-    // Wait for headless service to become available.
   }
 
   generateResponseFile(responseFile, args, createdPod, isAlpine)

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import * as core from '@actions/core'
 
 import { RunScriptStepArgs } from 'hooklib'
-import { execPodStep, getRootCertClientCertAndKey } from '../k8s'
+import { BackOffManager, execPodStep, getRootCertClientCertAndKey } from '../k8s'
 import {
   getEntryPointScriptContent,
   runScriptByGrpc,
@@ -15,6 +15,7 @@ import {
   GRPC_SCRIPT_EXECUTOR_PORT,
   JOB_CONTAINER_NAME
 } from './constants'
+import { MTLSCertAndPrivateKey } from 'src/k8s/certs'
 
 async function runScriptStepWithGRPC(
   args: RunScriptStepArgs,
@@ -29,26 +30,44 @@ async function runScriptStepWithGRPC(
     environmentVariables
   )
 
+  let rootCertClientAndKey: MTLSCertAndPrivateKey;
+  let serviceName: string;
   try {
     core.info('using script executor')
 
-    const serviceName = getServiceName()
+    serviceName = getServiceName()
     core.debug(`using service name ${serviceName}`)
 
-    const rootCertClientAndKey = await getRootCertClientCertAndKey()
+    rootCertClientAndKey = await getRootCertClientCertAndKey()
     core.debug('successfully retrieved root cert, client and key')
-    await runScriptByGrpc(
-      scriptContent,
-      rootCertClientAndKey.caCertAndkey.cert,
-      rootCertClientAndKey.clientCertAndKey.cert,
-      rootCertClientAndKey.clientCertAndKey.privateKey,
-      serviceName,
-      GRPC_SCRIPT_EXECUTOR_PORT
-    )
   } catch (err) {
-    core.error(`ScriptExecutorError failure: ${JSON.stringify(err)}`)
+    core.error(`ScriptExecutorError when trying to get cert: ${JSON.stringify(err)}`)
     const message = (err as any)?.response?.body?.message || err
-    throw new Error(`failed to run script step: ${message}`)
+    throw new Error(`failed to get script cert: ${message}`)
+  }
+
+  const backOffmanager = new BackOffManager(60)
+  while (true) {
+    try {
+      await runScriptByGrpc(
+        scriptContent,
+        rootCertClientAndKey.caCertAndkey.cert,
+        rootCertClientAndKey.clientCertAndKey.cert,
+        rootCertClientAndKey.clientCertAndKey.privateKey,
+        serviceName,
+        GRPC_SCRIPT_EXECUTOR_PORT
+      )
+      break;
+    } catch (err) {
+      core.error(`ScriptExecutorError when trying to get cert: ${JSON.stringify(err)}`)
+      const message = (err as any)?.response?.body?.message || err
+      if (String(message).includes("ECONNREFUSED")) {
+        core.debug('quoct ECONNREFUSED')
+        await backOffmanager.backOff()
+      } else {
+        break;
+      }
+    }
   }
 }
 

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -19,7 +19,6 @@ import {
   GRPC_SCRIPT_EXECUTOR_PORT,
   JOB_CONTAINER_NAME
 } from './constants'
-import { MTLSCertAndPrivateKey } from 'src/k8s/certs'
 
 async function runScriptStepWithGRPC(
   args: RunScriptStepArgs,
@@ -35,18 +34,8 @@ async function runScriptStepWithGRPC(
   )
 
   core.info('using script executor')
-
-  let rootCertClientAndKey: MTLSCertAndPrivateKey
-  try {
-    rootCertClientAndKey = await getRootCertClientCertAndKey()
-    core.debug('successfully retrieved root cert, client and key')
-  } catch (err) {
-    core.error(
-      `ScriptExecutorError when trying to get cert: ${JSON.stringify(err)}`
-    )
-    const message = (err as any)?.response?.body?.message || err
-    throw new Error(`failed to get script cert: ${message}`)
-  }
+  const rootCertClientAndKey = await getRootCertClientCertAndKey()
+  core.debug('successfully retrieved root cert, client and key')
 
   const backOffmanager = new BackOffManager(60)
   while (true) {

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -3,7 +3,11 @@ import * as fs from 'fs'
 import * as core from '@actions/core'
 
 import { RunScriptStepArgs } from 'hooklib'
-import { BackOffManager, execPodStep, getRootCertClientCertAndKey } from '../k8s'
+import {
+  BackOffManager,
+  execPodStep,
+  getRootCertClientCertAndKey
+} from '../k8s'
 import {
   getEntryPointScriptContent,
   runScriptByGrpc,
@@ -32,12 +36,14 @@ async function runScriptStepWithGRPC(
 
   core.info('using script executor')
 
-  let rootCertClientAndKey: MTLSCertAndPrivateKey;
-  try {    
+  let rootCertClientAndKey: MTLSCertAndPrivateKey
+  try {
     rootCertClientAndKey = await getRootCertClientCertAndKey()
     core.debug('successfully retrieved root cert, client and key')
   } catch (err) {
-    core.error(`ScriptExecutorError when trying to get cert: ${JSON.stringify(err)}`)
+    core.error(
+      `ScriptExecutorError when trying to get cert: ${JSON.stringify(err)}`
+    )
     const message = (err as any)?.response?.body?.message || err
     throw new Error(`failed to get script cert: ${message}`)
   }
@@ -53,15 +59,17 @@ async function runScriptStepWithGRPC(
         getServiceName(),
         GRPC_SCRIPT_EXECUTOR_PORT
       )
-      break;
+      break
     } catch (err) {
-      core.error(`ScriptExecutorError when trying to execute: ${JSON.stringify(err)}`)
+      core.error(
+        `ScriptExecutorError when trying to execute: ${JSON.stringify(err)}`
+      )
       const message = (err as any)?.response?.body?.message || err
-      if (String(message).includes("ECONNREFUSED")) {
+      if (String(message).includes('ECONNREFUSED')) {
         // Retry for 60s since the service may not be established.
         await backOffmanager.backOff()
       } else {
-        break;
+        break
       }
     }
   }

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -30,14 +30,10 @@ async function runScriptStepWithGRPC(
     environmentVariables
   )
 
+  core.info('using script executor')
+
   let rootCertClientAndKey: MTLSCertAndPrivateKey;
-  let serviceName: string;
-  try {
-    core.info('using script executor')
-
-    serviceName = getServiceName()
-    core.debug(`using service name ${serviceName}`)
-
+  try {    
     rootCertClientAndKey = await getRootCertClientCertAndKey()
     core.debug('successfully retrieved root cert, client and key')
   } catch (err) {
@@ -54,15 +50,15 @@ async function runScriptStepWithGRPC(
         rootCertClientAndKey.caCertAndkey.cert,
         rootCertClientAndKey.clientCertAndKey.cert,
         rootCertClientAndKey.clientCertAndKey.privateKey,
-        serviceName,
+        getServiceName(),
         GRPC_SCRIPT_EXECUTOR_PORT
       )
       break;
     } catch (err) {
-      core.error(`ScriptExecutorError when trying to get cert: ${JSON.stringify(err)}`)
+      core.error(`ScriptExecutorError when trying to execute: ${JSON.stringify(err)}`)
       const message = (err as any)?.response?.body?.message || err
       if (String(message).includes("ECONNREFUSED")) {
-        core.debug('quoct ECONNREFUSED')
+        // Retry for 60s since the service may not be established.
         await backOffmanager.backOff()
       } else {
         break;

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -57,6 +57,7 @@ async function runScriptStepWithGRPC(
       const message = (err as any)?.response?.body?.message || err
       if (String(message).includes('ECONNREFUSED')) {
         // Retry for 60s since the service may not be established.
+        core.debug(`Retrying execution for ECONNREFUSED.`)
         await backOffmanager.backOff()
       } else {
         break

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -37,6 +37,7 @@ async function runScriptStepWithGRPC(
   const rootCertClientAndKey = await getRootCertClientCertAndKey()
   core.debug('successfully retrieved root cert, client and key')
 
+  // This will throw after retrying with back off for up to 60s.
   const backOffmanager = new BackOffManager(60)
   while (true) {
     try {
@@ -50,7 +51,7 @@ async function runScriptStepWithGRPC(
       )
       break
     } catch (err) {
-      core.error(
+      core.debug(
         `ScriptExecutorError when trying to execute: ${JSON.stringify(err)}`
       )
       const message = (err as any)?.response?.body?.message || err

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -698,7 +698,7 @@ export function namespace(): string {
   return context.namespace
 }
 
-class BackOffManager {
+export class BackOffManager {
   private backOffSeconds = 1
   totalTime = 0
   constructor(private throwAfterSeconds?: number) {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -94,9 +94,9 @@ export async function createHeadlessService(): Promise<void> {
   })
 }
 
-export async function getHeadlessService(): Promise<void> {
+export async function getHeadlessService(): Promise<k8s.V1Service> {
   const serviceName = getServiceName()
-  await k8sApi.readNamespacedService({
+  return await k8sApi.readNamespacedService({
     namespace: namespace(),
     name: serviceName
   })

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -94,14 +94,6 @@ export async function createHeadlessService(): Promise<void> {
   })
 }
 
-export async function getHeadlessService(): Promise<k8s.V1Service> {
-  const serviceName = getServiceName()
-  return await k8sApi.readNamespacedService({
-    namespace: namespace(),
-    name: serviceName
-  })
-}
-
 export async function createPod(
   jobContainer?: k8s.V1Container,
   services?: k8s.V1Container[],

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -94,6 +94,14 @@ export async function createHeadlessService(): Promise<void> {
   })
 }
 
+export async function getHeadlessService(): Promise<void> {
+  const serviceName = getServiceName()
+  await k8sApi.readNamespacedService({
+    namespace: namespace(),
+    name: serviceName
+  })
+}
+
 export async function createPod(
   jobContainer?: k8s.V1Container,
   services?: k8s.V1Container[],


### PR DESCRIPTION
Add a retry logic with backoff for 60 seconds if there is a `ECONNREFUSED` when using script executor. This may happen if the service is not yet available.