### PR TITLE
Add a utility function to copy a local source folder to a path in a container

### DIFF
--- a/packages/k8s/package-lock.json
+++ b/packages/k8s/package-lock.json
@@ -20,6 +20,7 @@
         "js-yaml": "^4.1.0",
         "node-forge": "^1.3.1",
         "shlex": "^2.1.2",
+        "tar-fs": "^3.1.0",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -7165,7 +7166,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",

--- a/packages/k8s/package.json
+++ b/packages/k8s/package.json
@@ -24,6 +24,7 @@
     "js-yaml": "^4.1.0",
     "node-forge": "^1.3.1",
     "shlex": "^2.1.2",
+    "tar-fs": "^3.1.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -15,7 +15,8 @@ import {
   prunePods,
   waitForPodPhases,
   getPrepareJobTimeoutSeconds,
-  createHeadlessService
+  createHeadlessService,
+  extractErrorMessageFromK8sError
 } from '../k8s'
 import {
   containerVolumes,
@@ -84,7 +85,7 @@ export async function prepareJob(
   } catch (err) {
     await prunePods()
     core.debug(`createPod failed: ${JSON.stringify(err)}`)
-    const message = (err as any)?.response?.body?.message || err
+    const message = extractErrorMessageFromK8sError(err)
     throw new Error(`failed to create job pod: ${message}`)
   }
 
@@ -119,7 +120,7 @@ export async function prepareJob(
     core.debug(
       `Failed to determine if the pod is alpine: ${JSON.stringify(err)}`
     )
-    const message = (err as any)?.response?.body?.message || err
+    const message = extractErrorMessageFromK8sError(err)
     throw new Error(`failed to determine if the pod is alpine: ${message}`)
   }
   core.debug(`Setting isAlpine to ${isAlpine}`)

--- a/packages/k8s/src/hooks/run-container-step.ts
+++ b/packages/k8s/src/hooks/run-container-step.ts
@@ -4,6 +4,7 @@ import { RunContainerStepArgs } from 'hooklib'
 import {
   createJob,
   createSecretForEnvs,
+  extractErrorMessageFromK8sError,
   getContainerJobPodName,
   getPodLogs,
   getPodStatus,
@@ -38,8 +39,8 @@ export async function runContainerStep(
       }
       secretName = await createSecretForEnvs(envs)
     } catch (err) {
-      core.debug(`createSecretForEnvs failed: ${JSON.stringify(err)}`)
-      const message = (err as any)?.response?.body?.message || err
+      const message = extractErrorMessageFromK8sError(err)
+      core.debug(`createSecretForEnvs failed: ${message}`)
       throw new Error(`failed to create script environment: ${message}`)
     }
   }
@@ -53,8 +54,8 @@ export async function runContainerStep(
   try {
     job = await createJob(container, extension)
   } catch (err) {
-    core.debug(`createJob failed: ${JSON.stringify(err)}`)
-    const message = (err as any)?.response?.body?.message || err
+    const message = extractErrorMessageFromK8sError(err)
+    core.debug(`createJob failed: ${message}`)
     throw new Error(`failed to run script step: ${message}`)
   }
 
@@ -71,8 +72,8 @@ export async function runContainerStep(
   try {
     podName = await getContainerJobPodName(job.metadata.name)
   } catch (err) {
-    core.debug(`getContainerJobPodName failed: ${JSON.stringify(err)}`)
-    const message = (err as any)?.response?.body?.message || err
+    const message = extractErrorMessageFromK8sError(err)
+    core.debug(`getContainerJobPodName failed: ${message}`)
     throw new Error(`failed to get container job pod name: ${message}`)
   }
 

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -932,7 +932,7 @@ export async function cpToPod(
           }
         )
       } catch (error) {
-        const message = (error as any)?.response?.body?.message || error
+        const message = extractErrorMessageFromK8sError(error)
         core.debug(
           `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${message}`
         )
@@ -942,9 +942,11 @@ export async function cpToPod(
     core.debug('finished copying')
   } catch (error) {
     core.debug(
-      `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${JSON.stringify(
-        error
-      )}`
+      `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${error})}`
     )
   }
+}
+
+export function extractErrorMessageFromK8sError(error: unknown): string {
+  return String((error as any)?.response?.body?.message || error)
 }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -1,5 +1,7 @@
 import * as core from '@actions/core'
 import * as k8s from '@kubernetes/client-node'
+import * as tar from 'tar-fs'
+import { WritableStreamBuffer } from 'stream-buffers'
 import { ContainerInfo, Registry } from 'hooklib'
 import * as stream from 'stream'
 import {
@@ -31,6 +33,7 @@ kc.loadFromDefault()
 const k8sApi = kc.makeApiClient(k8s.CoreV1Api)
 const k8sBatchV1Api = kc.makeApiClient(k8s.BatchV1Api)
 const k8sAuthorizationV1Api = kc.makeApiClient(k8s.AuthorizationV1Api)
+const k8sExec = new k8s.Exec(kc)
 
 const DEFAULT_WAIT_FOR_POD_TIME_SECONDS = 10 * 60 // 10 min
 
@@ -886,4 +889,62 @@ export async function getRootCertClientCertAndKey(): Promise<MTLSCertAndPrivateK
     clientCertAndKey: { cert: clientCert, privateKey: clientKey }
   }
   return clientCertDicts[certDictKey]
+}
+
+/**
+ * Pack and copy srcPath (in the current host) over to tgtPath in the
+ * destination container containerName in pod PodName.
+ * This is using `kubectl exec` so it shouldn't be used for large files.
+ */
+export async function cpToPod(
+  podName: string,
+  containerName: string,
+  srcPath: string,
+  tgtPath: string
+): Promise<void> {
+  core.debug(`packing to ${srcPath}`)
+  const command = ['tar', 'xf', '-', '-C', tgtPath]
+  const readStream = tar.pack(srcPath)
+  const errStream = new WritableStreamBuffer()
+  try {
+    core.debug(`copying to ${tgtPath} in ${containerName} in ${podName}`)
+    await new Promise<void>(async (resolve, reject) => {
+      try {
+        await k8sExec.exec(
+          namespace(),
+          podName,
+          containerName,
+          command,
+          null,
+          errStream,
+          readStream,
+          false,
+          async () => {
+            if (errStream.size()) {
+              const errString = errStream.getContentsAsString()
+              core.debug(
+                `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${errString}`
+              )
+              reject(new Error(`Error from cpToPod - details: \n ${errString}`))
+            } else {
+              resolve()
+            }
+          }
+        )
+      } catch (error) {
+        const message = (error as any)?.response?.body?.message || error
+        core.debug(
+          `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${message}`
+        )
+        reject(error)
+      }
+    })
+    core.debug('finished copying')
+  } catch (error) {
+    core.debug(
+      `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${JSON.stringify(
+        error
+      )}`
+    )
+  }
 }

--- a/packages/k8s/tests/test-setup.ts
+++ b/packages/k8s/tests/test-setup.ts
@@ -90,7 +90,7 @@ export class TestHelper {
     fs.rmSync(filePath)
   }
 
-  public async createTestJobPod() {
+  public async createTestJobPod(): Promise<k8s.V1Pod> {
     const container = {
       name: 'nginx',
       image: 'nginx:latest',
@@ -106,7 +106,7 @@ export class TestHelper {
         containers: [container]
       }
     } as k8s.V1Pod
-    await k8sApi.createNamespacedPod({ namespace: 'default', body: pod })
+    return await k8sApi.createNamespacedPod({ namespace: 'default', body: pod })
   }
 
   public async createTestVolume() {


### PR DESCRIPTION
The copy is done by packing the source folder and transmits the file over kubectl exec to the destination folder. This is not meant to copy large files.
Also refactor a function to output error message from K8s.