### PR TITLE
Copy runner file commands from workflow to runner pods

### DIFF
--- a/packages/k8s/package-lock.json
+++ b/packages/k8s/package-lock.json
@@ -27,7 +27,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
-        "@types/node": "^17.0.23",
+        "@types/node": "^17.0.45",
         "@types/node-forge": "^1.3.11",
         "@vercel/ncc": "^0.33.4",
         "jest": "^29.7.0",
@@ -3729,7 +3729,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "17.0.36",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "license": "MIT"
     },
     "node_modules/@types/node-fetch": {

--- a/packages/k8s/package-lock.json
+++ b/packages/k8s/package-lock.json
@@ -15,6 +15,7 @@
         "@grpc/grpc-js": "^1.13.4",
         "@grpc/proto-loader": "^0.7.15",
         "@kubernetes/client-node": "^1.2.0",
+        "@types/tar-fs": "^2.0.4",
         "google-protobuf": "^3.21.4",
         "hooklib": "file:../hooklib",
         "js-yaml": "^4.1.0",
@@ -3756,6 +3757,25 @@
     },
     "node_modules/@types/stream-buffers": {
       "version": "3.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/tar-fs": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/tar-fs/-/tar-fs-2.0.4.tgz",
+      "integrity": "sha512-ipPec0CjTmVDWE+QKr9cTmIIoTl7dFG/yARCM5MqK8i6CNLIG1P8x4kwDsOQY1ChZOZjH0wO9nvfgBvWl4R3kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tar-stream": "*"
+      }
+    },
+    "node_modules/@types/tar-stream": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-3.1.4.tgz",
+      "integrity": "sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"

--- a/packages/k8s/package.json
+++ b/packages/k8s/package.json
@@ -19,6 +19,7 @@
     "@grpc/grpc-js": "^1.13.4",
     "@grpc/proto-loader": "^0.7.15",
     "@kubernetes/client-node": "^1.2.0",
+    "@types/tar-fs": "^2.0.4",
     "google-protobuf": "^3.21.4",
     "hooklib": "file:../hooklib",
     "js-yaml": "^4.1.0",

--- a/packages/k8s/package.json
+++ b/packages/k8s/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
-    "@types/node": "^17.0.23",
+    "@types/node": "^17.0.45",
     "@types/node-forge": "^1.3.11",
     "@vercel/ncc": "^0.33.4",
     "jest": "^29.7.0",

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -205,7 +205,7 @@ async function prepareJobSet(
     throw new Error(`failed to determine if the pod is alpine: ${message}`)
   }
 
-  core.info('pods from jobset are now online ')
+  core.debug('pods from jobset are now online ')
   generateResponseFile(responseFile, args, createdPod, isAlpine)
 }
 

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -155,7 +155,7 @@ async function prepareJobSet(
   extension?: k8s.V1PodTemplateSpec
 ): Promise<void> {
   const jobSetName = getJobSetName()
-  const noOfHosts = getNumberOfHost()
+  const noOfHosts = 1 // getNumberOfHost()
 
   const podSpec = await createPodSpec(jobContainer, [], null, extension)
   core.info(`creating JobSet ${jobSetName} for ${noOfHosts} hosts.`)

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -155,7 +155,7 @@ async function prepareJobSet(
   extension?: k8s.V1PodTemplateSpec
 ): Promise<void> {
   const jobSetName = getJobSetName()
-  const noOfHosts = 1 // getNumberOfHost()
+  const noOfHosts = getNumberOfHost()
 
   const podSpec = await createPodSpec(jobContainer, [], null, extension)
   core.info(`creating JobSet ${jobSetName} for ${noOfHosts} hosts.`)

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -146,7 +146,7 @@ async function runScriptStepInJobSet(
     )
     core.info(`syncing workflow pod to runner pod with copyFromPod`)
     // We can just copy from one of the pod.
-    await copyFromPod('/__w/_temp/', '_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
+    await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -122,7 +122,8 @@ async function runScriptStepInJobSet(
             `Running script by grpc in pod ${pod.metadata?.name} with prefix ${jobCompletionIndex}`
           )
           // For the 0th index, don't put a prefix.
-          const jobPrefix = jobCompletionIndex ? `job-${jobCompletionIndex}: ` : ''
+          const jobPrefix = jobCompletionIndex && Number(jobCompletionIndex) > 0 ? `job-${jobCompletionIndex}: ` : ''
+          core.info('job prefix is ' + jobPrefix)
           // TODO(quoct): Add a prefix to the log output
           return runScriptByGrpc(
             scriptContent,

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -92,6 +92,7 @@ async function runScriptStepInJobSet(
     core.debug(`retrieving pods from JobSet ${jobSetName}`)
     const pods = await getPodsFromJobSet(jobSetName)
 
+    core.debug(`syncing runner folders to workflow pods for ${jobSetName}`)
     await Promise.all(
       pods.items.map(async pod => {
         try {
@@ -100,6 +101,19 @@ async function runScriptStepInJobSet(
             pod.status!!.podIP!!,
             rootCertClientAndKey
           )
+        } catch (error) {
+          const message = extractErrorMessageFromK8sError(error)
+          throw new Error(
+            `MultiHostError when execing the pod ${pod.metadata?.name} in JobSet ${jobSetName}: ${message}`
+          )
+        }
+      })
+    )
+
+    core.debug(`executing script for ${jobSetName}`)
+    await Promise.all(
+      pods.items.map(async pod => {
+        try {
           const jobCompletionIndex =
             pod.metadata?.annotations!![
               'batch.kubernetes.io/job-completion-index'
@@ -107,6 +121,8 @@ async function runScriptStepInJobSet(
           core.debug(
             `Running script by grpc in pod ${pod.metadata?.name} with prefix ${jobCompletionIndex}`
           )
+          // For the 0th index, don't put a prefix.
+          const jobPrefix = jobCompletionIndex ? `job-${jobCompletionIndex}: ` : ''
           // TODO(quoct): Add a prefix to the log output
           return runScriptByGrpc(
             scriptContent,
@@ -116,7 +132,7 @@ async function runScriptStepInJobSet(
             pod.status!!.podIP!!,
             GRPC_SCRIPT_EXECUTOR_PORT,
             true,
-            `job-${jobCompletionIndex}: `
+            jobPrefix
           )
         } catch (error) {
           const message = extractErrorMessageFromK8sError(error)

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -144,10 +144,11 @@ async function runScriptStepInJobSet(
         }
       })
     )
-    await sleep(100000)
-    core.info(`syncing workflow pod to runner pod with copyFromPod`)
+    core.debug(`syncing workflow pod to runner pod with copyFromPod`)
     // We can just copy from one of the pod.
     await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
+    core.debug(`deon copying`)
+    await sleep(10000000)
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -157,14 +157,14 @@ async function runScriptStepInJobSet(
       join(tempTestDir, `${jobSetName}-${i}.out`)
     )
     if (jobOutput.length) {
-      core.notice(`Job ${i} output: \n`)
+      core.notice(`Job ${i} output`)
       process.stdout.write(jobOutput)
     }
     const jobError = fs.readFileSync(
       join(tempTestDir, `${jobSetName}-${i}.err`)
     )
     if (jobError.length) {
-      core.warning(`Job ${i} error: \n`)
+      core.warning(`Job ${i} error`)
       process.stderr.write(jobError)
     }
     indexToStreamMap[i][0].close()

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -124,7 +124,7 @@ async function runScriptStepInJobSet(
             `Running script by grpc in pod ${pod.metadata?.name} with prefix ${jobCompletionIndex}`
           )
           // For the 0th index, don't put a prefix.
-          const jobPrefix = jobCompletionIndex && Number(jobCompletionIndex) > 0 ? `job-${jobCompletionIndex}: ` : ''
+          // const jobPrefix = jobCompletionIndex && Number(jobCompletionIndex) > 0 ? `job-${jobCompletionIndex}: ` : ''
           // TODO(quoct): Add a prefix to the log output
           return runScriptByGrpc(
             scriptContent,
@@ -134,7 +134,7 @@ async function runScriptStepInJobSet(
             pod.status!!.podIP!!,
             GRPC_SCRIPT_EXECUTOR_PORT,
             true,
-            jobPrefix
+            `job-${jobCompletionIndex}`
           )
         } catch (error) {
           const message = extractErrorMessageFromK8sError(error)

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -132,7 +132,7 @@ async function runScriptStepInJobSet(
             pod.status!!.podIP!!,
             GRPC_SCRIPT_EXECUTOR_PORT,
             true,
-            `job-${jobCompletionIndex} `
+            `job-${jobCompletionIndex}`
           )
         } catch (error) {
           const message = extractErrorMessageFromK8sError(error)

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -145,6 +145,15 @@ async function runScriptStepInJobSet(
       })
     )
     core.debug(`syncing workflow pod to runner pod with copyFromPod`)
+    await runScriptByGrpc(
+      'ls /__w/_temp/_runner_file_commands; echo "contents", cat /__w/_temp/_runner_file_commands/*',
+      rootCertClientAndKey.caCertAndkey.cert,
+      rootCertClientAndKey.clientCertAndKey.cert,
+      rootCertClientAndKey.clientCertAndKey.privateKey,
+      pods.items[0].status!!.podIP!!,
+      GRPC_SCRIPT_EXECUTOR_PORT,
+      true
+    )
     // We can just copy from one of the pod.
     await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
     core.debug(`done copying`)

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -143,11 +143,7 @@ async function syncRunnerFolderToWorkflowPod(
   core.debug(
     'deleting _temp folder, /github/workflow/, _actions and /github/home/ folders'
   )
-  const command = `rm -rf /__w/_tool;
-rm -rf /__w/_actions;
-rm -rf /__w/_temp/*;
-rm -rf /github/home/*;
-rm -rf /github/workflow/*;
+  const command = `
 mkdir -p /github/home;
 mkdir -p /github/workflow;
 mkdir -p /__w/_temp;

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -157,14 +157,14 @@ async function runScriptStepInJobSet(
       join(tempTestDir, `${jobSetName}-${i}.out`)
     )
     if (jobOutput.length) {
-      process.stdout.write(`job ${i} output: \n`)
+      core.notice(`Job ${i} output: \n`)
       process.stdout.write(jobOutput)
     }
     const jobError = fs.readFileSync(
       join(tempTestDir, `${jobSetName}-${i}.err`)
     )
     if (jobError.length) {
-      process.stderr.write(`job ${i} error: \n`)
+      core.warning(`Job ${i} error: \n`)
       process.stderr.write(jobError)
     }
     indexToStreamMap[i][0].close()

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -5,6 +5,7 @@ import * as core from '@actions/core'
 import { RunScriptStepArgs } from 'hooklib'
 import {
   BackOffManager,
+  copyFromPod,
   cpToPod,
   execPodStep,
   extractErrorMessageFromK8sError,
@@ -143,6 +144,9 @@ async function runScriptStepInJobSet(
         }
       })
     )
+    core.info(`syncing workflow pod to runner pod`)
+    // We can just copy from one of the pod.
+    await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -123,9 +123,7 @@ async function runScriptStepInJobSet(
           core.debug(
             `Running script by grpc in pod ${pod.metadata?.name} with prefix ${jobCompletionIndex}`
           )
-          // For the 0th index, don't put a prefix.
-          // const jobPrefix = jobCompletionIndex && Number(jobCompletionIndex) > 0 ? `job-${jobCompletionIndex}: ` : ''
-          // TODO(quoct): Add a prefix to the log output
+
           return runScriptByGrpc(
             scriptContent,
             rootCertClientAndKey.caCertAndkey.cert,
@@ -134,7 +132,7 @@ async function runScriptStepInJobSet(
             pod.status!!.podIP!!,
             GRPC_SCRIPT_EXECUTOR_PORT,
             true,
-            `(job-${jobCompletionIndex}): `
+            `job-${jobCompletionIndex} `
           )
         } catch (error) {
           const message = extractErrorMessageFromK8sError(error)

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -33,7 +33,7 @@ async function runScriptStepWithGRPC(
   state
 ): Promise<void> {
   const runnerDir = `/home/runner/_work/_temp/_runner_file_commands`
-  const files = fs.readdirSync('/home/runner/_work/_temp/_runner_file_commands');
+  const files = fs.readdirSync('/home/runner/_work/_temp/_runner_file_commands')
 
   const { entryPoint, entryPointArgs, environmentVariables } = args
   const scriptContent = getEntryPointScriptContent(
@@ -134,7 +134,7 @@ async function runScriptStepInJobSet(
             pod.status!!.podIP!!,
             GRPC_SCRIPT_EXECUTOR_PORT,
             true,
-            `job-${jobCompletionIndex}`
+            `(job-${jobCompletionIndex}): `
           )
         } catch (error) {
           const message = extractErrorMessageFromK8sError(error)
@@ -146,7 +146,12 @@ async function runScriptStepInJobSet(
     )
 
     core.debug(`syncing workflow pod to runner pod with copyFromPod`)
-    await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
+    await copyFromPod(
+      '/__w/_temp/_runner_file_commands',
+      '/home/runner/_work/_temp/_runner_file_commands',
+      pods.items[0].metadata!!.name!!,
+      JOB_CONTAINER_NAME
+    )
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -148,7 +148,6 @@ async function runScriptStepInJobSet(
     // We can just copy from one of the pod.
     await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
     core.debug(`done copying`)
-    await sleep(50000)
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -27,6 +27,9 @@ import {
   JOB_CONTAINER_NAME
 } from './constants'
 import { MTLSCertAndPrivateKey } from '../k8s/certs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { Writable } from 'stream'
 
 async function runScriptStepWithGRPC(
   args: RunScriptStepArgs,
@@ -49,7 +52,14 @@ async function runScriptStepWithGRPC(
   core.debug('successfully retrieved root cert, client and key')
 
   if (getNumberOfHost() > 1) {
-    return runScriptStepInJobSet(scriptContent, rootCertClientAndKey)
+    try {
+      return runScriptStepInJobSet(scriptContent, rootCertClientAndKey)
+    } catch (error) {
+      const message = extractErrorMessageFromK8sError(error)
+      throw new Error(
+        `MultiHostError when execing pods in JobSet ${getJobSetName()}: ${message}`
+      )
+    }
   }
 
   // This will throw after retrying with back off for up to 60s.
@@ -89,71 +99,79 @@ async function runScriptStepInJobSet(
     throw new Error(`JobSet ${jobSetName} does not exist.`)
   }
 
-  try {
-    core.debug(`retrieving pods from JobSet ${jobSetName}`)
-    const pods = await getPodsFromJobSet(jobSetName)
+  core.debug(`retrieving pods from JobSet ${jobSetName}`)
+  const pods = await getPodsFromJobSet(jobSetName)
 
-    core.debug(`syncing runner folders to workflow pods for ${jobSetName}`)
-    await Promise.all(
-      pods.items.map(async pod => {
-        try {
-          await syncRunnerFolderToWorkflowPod(
-            pod.metadata?.name!!,
-            pod.status!!.podIP!!,
-            rootCertClientAndKey
-          )
-        } catch (error) {
-          const message = extractErrorMessageFromK8sError(error)
-          throw new Error(
-            `MultiHostError when execing the pod ${pod.metadata?.name} in JobSet ${jobSetName}: ${message}`
-          )
-        }
-      })
-    )
+  core.debug(`syncing runner folders to workflow pods for ${jobSetName}`)
+  await Promise.all(
+    pods.items.map(async pod => {
+      core.debug(`sync runner folder to workflow pod ${pod.metadata?.name}`)
+      await syncRunnerFolderToWorkflowPod(
+        pod.metadata?.name!!,
+        pod.status!!.podIP!!,
+        rootCertClientAndKey
+      )
+    })
+  )
 
-    core.debug(`executing script for ${jobSetName}`)
-    await Promise.all(
-      pods.items.map(async pod => {
-        try {
-          const jobCompletionIndex =
-            pod.metadata?.annotations!![
-              'batch.kubernetes.io/job-completion-index'
-            ]
-          core.debug(
-            `Running script by grpc in pod ${pod.metadata?.name} with prefix ${jobCompletionIndex}`
-          )
-
-          if (Number(jobCompletionIndex) === 0) {
-            return runScriptByGrpc(
-              scriptContent,
-              rootCertClientAndKey.caCertAndkey.cert,
-              rootCertClientAndKey.clientCertAndKey.cert,
-              rootCertClientAndKey.clientCertAndKey.privateKey,
-              pod.status!!.podIP!!
-            )
-          }
-        } catch (error) {
-          const message = extractErrorMessageFromK8sError(error)
-          throw new Error(
-            `MultiHostError when execing the pod ${pod.metadata?.name} in JobSet ${jobSetName}: ${message}`
-          )
-        }
-      })
-    )
-
-    core.debug(`syncing workflow pod to runner pod with copyFromPod`)
-    await copyFromPod(
-      '/__w/_temp/_runner_file_commands',
-      '/home/runner/_work/_temp/_runner_file_commands',
-      pods.items[0].metadata!!.name!!,
-      JOB_CONTAINER_NAME
-    )
-  } catch (error) {
-    const message = extractErrorMessageFromK8sError(error)
-    throw new Error(
-      `MultiHostError when execing pods in JobSet ${jobSetName}: ${message}`
-    )
+  const tempTestDir = fs.mkdtempSync(tmpdir())
+  const indexToStreamMap: Map<number, [output: Writable, errStream: Writable]> =
+    new Map()
+  for (let i = 0; i < pods.items.length; i += 1) {
+    indexToStreamMap[i] = [
+      i === 0
+        ? process.stdout
+        : fs.createWriteStream(join(tempTestDir, `${jobSetName}-${i}.out`)),
+      i === 0
+        ? process.stderr
+        : fs.createWriteStream(join(tempTestDir, `${jobSetName}-${i}.err`))
+    ]
   }
+
+  core.debug(`executing script for ${jobSetName}`)
+  await Promise.all(
+    pods.items.map(async pod => {
+      const jobCompletionIndex = Number(
+        pod.metadata?.annotations!!['batch.kubernetes.io/job-completion-index']
+      )
+      core.debug(
+        `Running script by grpc in pod ${pod.metadata?.name} with prefix ${jobCompletionIndex}`
+      )
+
+      return runScriptByGrpc(
+        scriptContent,
+        rootCertClientAndKey.caCertAndkey.cert,
+        rootCertClientAndKey.clientCertAndKey.cert,
+        rootCertClientAndKey.clientCertAndKey.privateKey,
+        pod.status!!.podIP!!,
+        GRPC_SCRIPT_EXECUTOR_PORT,
+        indexToStreamMap[jobCompletionIndex][0],
+        indexToStreamMap[jobCompletionIndex][1]
+      )
+    })
+  )
+
+  for (let i = 1; i < pods.items.length; i += 1) {
+    process.stdout.write(`job ${i} output: \n`)
+    // The file should fit in the buffer.
+    process.stdout.write(
+      fs.readFileSync(join(tempTestDir, `${jobSetName}-${i}.out`))
+    )
+    process.stdout.write(`job ${i} error: \n`)
+    process.stderr.write(
+      fs.readFileSync(join(tempTestDir, `${jobSetName}-${i}.err`))
+    )
+    indexToStreamMap[i][0].close()
+    indexToStreamMap[i][1].close()
+  }
+
+  core.debug(`syncing workflow pod to runner pod with copyFromPod`)
+  await copyFromPod(
+    '/__w/_temp/_runner_file_commands',
+    '/home/runner/_work/_temp/_runner_file_commands',
+    pods.items[0].metadata!!.name!!,
+    JOB_CONTAINER_NAME
+  )
 }
 
 async function syncRunnerFolderToWorkflowPod(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -147,8 +147,8 @@ async function runScriptStepInJobSet(
     core.debug(`syncing workflow pod to runner pod with copyFromPod`)
     // We can just copy from one of the pod.
     await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
-    core.debug(`deon copying`)
-    await sleep(10000000)
+    core.debug(`done copying`)
+    await sleep(50000)
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -44,6 +44,7 @@ async function runScriptStepWithGRPC(
   core.info('using script executor')
   const rootCertClientAndKey = await getRootCertClientCertAndKey()
   core.debug('successfully retrieved root cert, client and key')
+  core.info('script content is ' + scriptContent)
 
   if (getNumberOfHost() > 1) {
     return runScriptStepInJobSet(scriptContent, rootCertClientAndKey)

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -28,20 +28,23 @@ import {
   JOB_CONTAINER_NAME
 } from './constants'
 import { MTLSCertAndPrivateKey } from '../k8s/certs'
+import { join } from 'path'
 
 async function runScriptStepWithGRPC(
   args: RunScriptStepArgs,
   state
 ): Promise<void> {
+  const runnerDir = `/home/runner/_work/_temp/_runner_file_commands`
   const files = fs.readdirSync('/home/runner/_work/_temp/_runner_file_commands');
 
   core.debug('read files before')
   for (const file of files) {
-    core.debug(`content of  file ${file}`)
-    const stats = await fs.promises.stat(file);
+    const filePath = join(runnerDir, file)
+    core.debug(`content of file ${filePath}`)
+    const stats = fs.statSync(filePath)
 
     if (stats.isFile()) {
-      const content = fs.readFileSync(file).toString();
+      const content = fs.readFileSync(filePath).toString();
       core.debug(content)
     }
   }
@@ -173,12 +176,14 @@ async function runScriptStepInJobSet(
 
     const files = fs.readdirSync('/home/runner/_work/_temp/_runner_file_commands');
 
+    core.debug('read files after')
     for (const file of files) {
-      core.debug(`content of  file ${file}`)
-      const stats = await fs.promises.stat(file);
-
+      const filePath = join('/home/runner/_work/_temp/_runner_file_commands', file)
+      core.debug(`content of file ${filePath}`)
+      const stats = fs.statSync(filePath)
+  
       if (stats.isFile()) {
-        const content = fs.readFileSync(file).toString();
+        const content = fs.readFileSync(filePath).toString();
         core.debug(content)
       }
     }

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -114,7 +114,7 @@ async function runScriptStepInJobSet(
     })
   )
 
-  const tempTestDir = fs.mkdtempSync(tmpdir())
+  const tempTestDir = tmpdir()
   const indexToStreamMap: Map<number, [output: Writable, errStream: Writable]> =
     new Map()
   for (let i = 0; i < pods.items.length; i += 1) {

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -152,15 +152,17 @@ async function runScriptStepInJobSet(
   )
 
   for (let i = 1; i < pods.items.length; i += 1) {
-    process.stdout.write(`job ${i} output: \n`)
+    process.stdout.write(`::group::job ${i} output`)
     // The file should fit in the buffer.
     process.stdout.write(
       fs.readFileSync(join(tempTestDir, `${jobSetName}-${i}.out`))
     )
-    process.stdout.write(`job ${i} error: \n`)
+    process.stdout.write(`::endgroup::`)
+    process.stdout.write(`::group::job ${i} error`)
     process.stderr.write(
       fs.readFileSync(join(tempTestDir, `${jobSetName}-${i}.err`))
     )
+    process.stdout.write(`::endgroup::`)
     indexToStreamMap[i][0].close()
     indexToStreamMap[i][1].close()
   }

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -152,17 +152,17 @@ async function runScriptStepInJobSet(
   )
 
   for (let i = 1; i < pods.items.length; i += 1) {
-    process.stdout.write(`::group::job ${i} output`)
+    core.startGroup(`job ${i} output`)
     // The file should fit in the buffer.
     process.stdout.write(
       fs.readFileSync(join(tempTestDir, `${jobSetName}-${i}.out`))
     )
-    process.stdout.write(`::endgroup::`)
-    process.stdout.write(`::group::job ${i} error`)
+    core.endGroup()
+    core.startGroup(`job ${i} error`)
     process.stderr.write(
       fs.readFileSync(join(tempTestDir, `${jobSetName}-${i}.err`))
     )
-    process.stdout.write(`::endgroup::`)
+    core.endGroup()
     indexToStreamMap[i][0].close()
     indexToStreamMap[i][1].close()
   }

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -144,9 +144,9 @@ async function runScriptStepInJobSet(
         }
       })
     )
-    core.info(`syncing workflow pod to runner pod`)
+    core.info(`syncing workflow pod to runner pod with copyFromPod`)
     // We can just copy from one of the pod.
-    await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
+    await copyFromPod('/__w/_temp/', '_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -144,6 +144,7 @@ async function runScriptStepInJobSet(
         }
       })
     )
+    await sleep(100000)
     core.info(`syncing workflow pod to runner pod with copyFromPod`)
     // We can just copy from one of the pod.
     await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -33,6 +33,19 @@ async function runScriptStepWithGRPC(
   args: RunScriptStepArgs,
   state
 ): Promise<void> {
+  const files = fs.readdirSync('/home/runner/_work/_temp/_runner_file_commands');
+
+  core.debug('read files before')
+  for (const file of files) {
+    core.debug(`content of  file ${file}`)
+    const stats = await fs.promises.stat(file);
+
+    if (stats.isFile()) {
+      const content = fs.readFileSync(file).toString();
+      core.debug(content)
+    }
+  }
+
   const { entryPoint, entryPointArgs, environmentVariables } = args
   const scriptContent = getEntryPointScriptContent(
     args.workingDirectory,
@@ -157,6 +170,18 @@ async function runScriptStepInJobSet(
     // We can just copy from one of the pod.
     await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
     core.debug(`done copying`)
+
+    const files = fs.readdirSync('/home/runner/_work/_temp/_runner_file_commands');
+
+    for (const file of files) {
+      core.debug(`content of  file ${file}`)
+      const stats = await fs.promises.stat(file);
+
+      if (stats.isFile()) {
+        const content = fs.readFileSync(file).toString();
+        core.debug(content)
+      }
+    }
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -146,7 +146,7 @@ async function runScriptStepInJobSet(
     )
     core.debug(`syncing workflow pod to runner pod with copyFromPod`)
     await runScriptByGrpc(
-      'ls /__w/_temp/_runner_file_commands; echo "contents", cat /__w/_temp/_runner_file_commands/*',
+      'ls /__w/_temp/_runner_file_commands; echo "contents"; cat /__w/_temp/_runner_file_commands/*',
       rootCertClientAndKey.caCertAndkey.cert,
       rootCertClientAndKey.clientCertAndKey.cert,
       rootCertClientAndKey.clientCertAndKey.privateKey,

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -37,18 +37,6 @@ async function runScriptStepWithGRPC(
   const runnerDir = `/home/runner/_work/_temp/_runner_file_commands`
   const files = fs.readdirSync('/home/runner/_work/_temp/_runner_file_commands');
 
-  core.debug('read files before')
-  for (const file of files) {
-    const filePath = join(runnerDir, file)
-    core.debug(`content of file ${filePath}`)
-    const stats = fs.statSync(filePath)
-
-    if (stats.isFile()) {
-      const content = fs.readFileSync(filePath).toString();
-      core.debug(content)
-    }
-  }
-
   const { entryPoint, entryPointArgs, environmentVariables } = args
   const scriptContent = getEntryPointScriptContent(
     args.workingDirectory,
@@ -61,7 +49,6 @@ async function runScriptStepWithGRPC(
   core.info('using script executor')
   const rootCertClientAndKey = await getRootCertClientCertAndKey()
   core.debug('successfully retrieved root cert, client and key')
-  core.info('script content is ' + scriptContent)
 
   if (getNumberOfHost() > 1) {
     return runScriptStepInJobSet(scriptContent, rootCertClientAndKey)
@@ -140,7 +127,6 @@ async function runScriptStepInJobSet(
           )
           // For the 0th index, don't put a prefix.
           const jobPrefix = jobCompletionIndex && Number(jobCompletionIndex) > 0 ? `job-${jobCompletionIndex}: ` : ''
-          core.info('job prefix is ' + jobPrefix)
           // TODO(quoct): Add a prefix to the log output
           return runScriptByGrpc(
             scriptContent,
@@ -160,33 +146,11 @@ async function runScriptStepInJobSet(
         }
       })
     )
+
     core.debug(`syncing workflow pod to runner pod with copyFromPod`)
-    await runScriptByGrpc(
-      'ls /__w/_temp/_runner_file_commands; echo "contents"; cat /__w/_temp/_runner_file_commands/*',
-      rootCertClientAndKey.caCertAndkey.cert,
-      rootCertClientAndKey.clientCertAndKey.cert,
-      rootCertClientAndKey.clientCertAndKey.privateKey,
-      pods.items[0].status!!.podIP!!,
-      GRPC_SCRIPT_EXECUTOR_PORT,
-      true
-    )
-    // We can just copy from one of the pod.
     await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
-    core.debug(`done copying`)
 
     const files = fs.readdirSync('/home/runner/_work/_temp/_runner_file_commands');
-
-    core.debug('read files after')
-    for (const file of files) {
-      const filePath = join('/home/runner/_work/_temp/_runner_file_commands', file)
-      core.debug(`content of file ${filePath}`)
-      const stats = fs.statSync(filePath)
-  
-      if (stats.isFile()) {
-        const content = fs.readFileSync(filePath).toString();
-        core.debug(content)
-      }
-    }
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -151,18 +151,22 @@ async function runScriptStepInJobSet(
     })
   )
 
+  // Output the output and error for the rest of the jobs.
   for (let i = 1; i < pods.items.length; i += 1) {
-    core.startGroup(`job ${i} output`)
-    // The file should fit in the buffer.
-    process.stdout.write(
-      fs.readFileSync(join(tempTestDir, `${jobSetName}-${i}.out`))
+    const jobOutput = fs.readFileSync(
+      join(tempTestDir, `${jobSetName}-${i}.out`)
     )
-    core.endGroup()
-    core.startGroup(`job ${i} error`)
-    process.stderr.write(
-      fs.readFileSync(join(tempTestDir, `${jobSetName}-${i}.err`))
+    if (jobOutput.length) {
+      process.stdout.write(`job ${i} output: \n`)
+      process.stdout.write(jobOutput)
+    }
+    const jobError = fs.readFileSync(
+      join(tempTestDir, `${jobSetName}-${i}.err`)
     )
-    core.endGroup()
+    if (jobError.length) {
+      process.stderr.write(`job ${i} error: \n`)
+      process.stderr.write(jobError)
+    }
     indexToStreamMap[i][0].close()
     indexToStreamMap[i][1].close()
   }

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -61,8 +61,7 @@ async function runScriptStepWithGRPC(
         rootCertClientAndKey.caCertAndkey.cert,
         rootCertClientAndKey.clientCertAndKey.cert,
         rootCertClientAndKey.clientCertAndKey.privateKey,
-        getServiceName(),
-        GRPC_SCRIPT_EXECUTOR_PORT
+        getServiceName()
       )
       break
     } catch (err) {
@@ -124,16 +123,15 @@ async function runScriptStepInJobSet(
             `Running script by grpc in pod ${pod.metadata?.name} with prefix ${jobCompletionIndex}`
           )
 
-          return runScriptByGrpc(
-            scriptContent,
-            rootCertClientAndKey.caCertAndkey.cert,
-            rootCertClientAndKey.clientCertAndKey.cert,
-            rootCertClientAndKey.clientCertAndKey.privateKey,
-            pod.status!!.podIP!!,
-            GRPC_SCRIPT_EXECUTOR_PORT,
-            true,
-            `job-${jobCompletionIndex}`
-          )
+          if (Number(jobCompletionIndex) === 0) {
+            return runScriptByGrpc(
+              scriptContent,
+              rootCertClientAndKey.caCertAndkey.cert,
+              rootCertClientAndKey.clientCertAndKey.cert,
+              rootCertClientAndKey.clientCertAndKey.privateKey,
+              pod.status!!.podIP!!
+            )
+          }
         } catch (error) {
           const message = extractErrorMessageFromK8sError(error)
           throw new Error(
@@ -158,7 +156,6 @@ async function runScriptStepInJobSet(
   }
 }
 
-// TODO(quoct): Check if we can optimize and not delete the _actions folder every time.
 async function syncRunnerFolderToWorkflowPod(
   podName: string,
   podIp: string,
@@ -179,7 +176,8 @@ mkdir -p /__w/_tool`
     rootCertClientAndKey.clientCertAndKey.privateKey,
     podIp,
     GRPC_SCRIPT_EXECUTOR_PORT,
-    false
+    undefined,
+    undefined
   )
 
   core.debug(
@@ -220,7 +218,8 @@ mkdir -p /__w/_tool`
     rootCertClientAndKey.clientCertAndKey.privateKey,
     podIp,
     GRPC_SCRIPT_EXECUTOR_PORT,
-    false
+    undefined,
+    undefined
   )
 }
 

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -17,7 +17,6 @@ import {
   getEntryPointScriptContent,
   getNumberOfHost,
   runScriptByGrpc,
-  sleep,
   useScriptExecutor,
   writeEntryPointScript
 } from '../k8s/utils'
@@ -28,7 +27,6 @@ import {
   JOB_CONTAINER_NAME
 } from './constants'
 import { MTLSCertAndPrivateKey } from '../k8s/certs'
-import { join } from 'path'
 
 async function runScriptStepWithGRPC(
   args: RunScriptStepArgs,

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -166,10 +166,7 @@ async function syncRunnerFolderToWorkflowPod(
   podIp: string,
   rootCertClientAndKey: MTLSCertAndPrivateKey
 ): Promise<void> {
-  // TODO(quoct): Check if we can optimize and not delete the _actions folder every time.
-  core.debug(
-    'deleting _temp folder, /github/workflow/, _actions and /github/home/ folders'
-  )
+  core.debug('create folders used by GitHub Actions.')
   const command = `
 mkdir -p /github/home;
 mkdir -p /github/workflow;
@@ -187,7 +184,7 @@ mkdir -p /__w/_tool`
     false
   )
 
-  core.info(
+  core.debug(
     `copying temp folder for ${podName} in ${JOB_CONTAINER_NAME} container`
   )
   await cpToPod(
@@ -198,7 +195,7 @@ mkdir -p /__w/_tool`
   )
 
   if (fs.existsSync('/home/runner/_work/_actions')) {
-    core.info('copying /home/runner/_work/_actions')
+    core.debug('copying /home/runner/_work/_actions')
     await cpToPod(
       podName,
       JOB_CONTAINER_NAME,
@@ -208,7 +205,7 @@ mkdir -p /__w/_tool`
   }
 
   if (fs.existsSync('/home/runner/_work/_tool')) {
-    core.info('copying /home/runner/_work/_tool')
+    core.debug('copying /home/runner/_work/_tool')
     await cpToPod(
       podName,
       JOB_CONTAINER_NAME,
@@ -217,7 +214,7 @@ mkdir -p /__w/_tool`
     )
   }
 
-  core.info('copying github_home and github_workflow folder')
+  core.debug('copying github_home and github_workflow folder')
   await runScriptByGrpc(
     'cp -a /__w/_temp/_github_home/. /github/home/; cp -a /__w/_temp/_github_workflow/. /github/workflow',
     rootCertClientAndKey.caCertAndkey.cert,

--- a/packages/k8s/src/hooks/run-script-step.ts
+++ b/packages/k8s/src/hooks/run-script-step.ts
@@ -149,8 +149,6 @@ async function runScriptStepInJobSet(
 
     core.debug(`syncing workflow pod to runner pod with copyFromPod`)
     await copyFromPod('/__w/_temp/_runner_file_commands', '/home/runner/_work/_temp/_runner_file_commands', pods.items[0].metadata!!.name!!, JOB_CONTAINER_NAME)
-
-    const files = fs.readdirSync('/home/runner/_work/_temp/_runner_file_commands');
   } catch (error) {
     const message = extractErrorMessageFromK8sError(error)
     throw new Error(

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -924,52 +924,46 @@ export async function copyFromPod(
   }
   const extract = tar.extract(localPath)
 
-  try {
-    core.debug(`copying files from ${sourcePathFolder} to ${localPath}`)
-    await new Promise<void>(async (resolve, reject) => {
-      try {
-        await k8sExec.exec(
-          namespace(),
-          podName,
-          containerName,
-          command,
-          extract,
-          errStream,
-          null,
-          false,
-          async () => {
-            if (errStream.size()) {
-              const errString = stringify(errStream.getContentsAsString())
-              core.debug(
-                `error copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${errString}`
-              )
-              reject(new Error(`Error from cpToPod - details: \n ${errString}`))
-            } else {
-              core.debug('wait for extraction to finish')
-              extract.on('error', err => {
-                core.debug(`error extracting ${err}`)
-                reject(new Error(`error extracting ${err}`))
-              })
-              extract.on('finish', () => {
-                core.debug(`extract finished copying `)
-                resolve()
-              })
-            }
+  core.debug(`copying files from ${sourcePathFolder} to ${localPath}`)
+  await new Promise<void>(async (resolve, reject) => {
+    try {
+      await k8sExec.exec(
+        namespace(),
+        podName,
+        containerName,
+        command,
+        extract,
+        errStream,
+        null,
+        false,
+        async () => {
+          if (errStream.size()) {
+            const errString = stringify(errStream.getContentsAsString())
+            core.debug(
+              `error copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${errString}`
+            )
+            reject(new Error(`Error from cpToPod - details: \n ${errString}`))
+          } else {
+            core.debug('wait for extraction to finish')
+            extract.on('error', err => {
+              core.debug(`error extracting ${err}`)
+              reject(new Error(`error extracting ${err}`))
+            })
+            extract.on('finish', () => {
+              core.debug(`extract finished copying `)
+              resolve()
+            })
           }
-        )
-      } catch (error) {
-        const message = extractErrorMessageFromK8sError(error)
-        core.debug(
-          `error copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${message}`
-        )
-        reject(error)
-      }
-    })
-  } catch (error) {
-    core.debug(
-      `error copying from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${error})}`
-    )
-  }
+        }
+      )
+    } catch (error) {
+      const message = extractErrorMessageFromK8sError(error)
+      core.debug(
+        `error copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${message}`
+      )
+      reject(error)
+    }
+  })
 }
 
 /**
@@ -987,45 +981,40 @@ export async function cpToPod(
   const command = ['tar', 'xf', '-', '-C', tgtPath]
   const readStream = tar.pack(srcPath)
   const errStream = new WritableStreamBuffer()
-  try {
-    core.debug(`copying to ${tgtPath} in ${containerName} in ${podName}`)
-    await new Promise<void>(async (resolve, reject) => {
-      try {
-        await k8sExec.exec(
-          namespace(),
-          podName,
-          containerName,
-          command,
-          null,
-          errStream,
-          readStream,
-          false,
-          async () => {
-            if (errStream.size()) {
-              const errString = stringify(errStream.getContentsAsString())
-              core.debug(
-                `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${errString}`
-              )
-              reject(new Error(`Error from cpToPod - details: \n ${errString}`))
-            } else {
-              resolve()
-            }
+
+  core.debug(`copying to ${tgtPath} in ${containerName} in ${podName}`)
+  await new Promise<void>(async (resolve, reject) => {
+    try {
+      await k8sExec.exec(
+        namespace(),
+        podName,
+        containerName,
+        command,
+        null,
+        errStream,
+        readStream,
+        false,
+        async () => {
+          if (errStream.size()) {
+            const errString = stringify(errStream.getContentsAsString())
+            core.debug(
+              `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${errString}`
+            )
+            reject(new Error(`Error from cpToPod - details: \n ${errString}`))
+          } else {
+            resolve()
           }
-        )
-      } catch (error) {
-        const message = extractErrorMessageFromK8sError(error)
-        core.debug(
-          `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${message}`
-        )
-        reject(error)
-      }
-    })
-    core.debug('finished copying')
-  } catch (error) {
-    core.debug(
-      `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${error})}`
-    )
-  }
+        }
+      )
+    } catch (error) {
+      const message = extractErrorMessageFromK8sError(error)
+      core.debug(
+        `error copying ${srcPath} to ${tgtPath} in ${containerName} in pod ${podName}: ${message}`
+      )
+      reject(error)
+    }
+  })
+  core.debug('finished copying')
 }
 
 export function extractErrorMessageFromK8sError(error: unknown): string {

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -24,7 +24,8 @@ import {
   fixArgs,
   createScriptExecutorContainer,
   useScriptExecutor,
-  getNumberOfHost
+  getNumberOfHost,
+  sleep
 } from './utils'
 import { generateCerts, MTLSCertAndPrivateKey } from './certs'
 import { v4 as uuidv4 } from 'uuid'
@@ -911,7 +912,6 @@ export async function getRootCertClientCertAndKey(): Promise<MTLSCertAndPrivateK
 export async function copyFromPod(sourcePath: string, localPath: string, podName: string, containerName: string) {
   const command = ['tar', 'cf', '-', '-C', path.dirname(sourcePath), path.basename(sourcePath)]
   const errStream = new WritableStreamBuffer()
-  const writerStream = fs.createWriteStream(path.join(localPath, `tmp-${uuidv4().substring(0, 5)}.tar`));
 
   if (!fs.existsSync(localPath)) {
     fs.mkdirSync(localPath, { recursive: true})
@@ -951,7 +951,8 @@ export async function copyFromPod(sourcePath: string, localPath: string, podName
         reject(error)
       }
     })
-    core.info('finished copying')
+    core.info('finished copying ')
+    await sleep(100000)
   } catch (error) {
     core.debug(
       `error 2 copying to ${localPath} from ${sourcePath} in pod ${podName}: ${error})}`

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -921,7 +921,7 @@ export async function copyFromPod(sourcePathFolder: string, localPath: string, p
 
   try {
     core.info(`copying files from ${sourcePathFolder} to ${localPath}`)
-    await new Promise<void>(async (resolve, reject) => {
+    const execPromise = new Promise<void>(async (resolve, reject) => {
       try {
         await k8sExec.exec(
           namespace(),
@@ -940,7 +940,15 @@ export async function copyFromPod(sourcePathFolder: string, localPath: string, p
               )
               reject(new Error(`Error from cpToPod - details: \n ${errString}`))
             } else {
-              resolve()
+              core.debug('wait for extracting to finish')
+              extract.on("error", err => {
+                core.debug(`Error extracting ${err}`)
+                reject()
+              })
+              extract.on("finish", () => {
+                core.debug(`Extract finished copying `)
+                resolve()
+              })
             }
           }
         )
@@ -952,13 +960,6 @@ export async function copyFromPod(sourcePathFolder: string, localPath: string, p
         reject(error)
       }
     })
-    extract.on("error", err => {
-      core.debug(`Error extracting ${err}`)
-    })
-    extract.on("finish", () => {
-      core.debug("extract finished copying")
-    })
-    core.info('finished copying ')
   } catch (error) {
     core.debug(
       `error copying from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${error})}`

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -28,6 +28,7 @@ import {
 } from './utils'
 import { generateCerts, MTLSCertAndPrivateKey } from './certs'
 import { v4 as uuidv4 } from 'uuid'
+import { createWriteStream, readFileSync } from 'fs'
 
 const kc = new k8s.KubeConfig()
 
@@ -904,6 +905,52 @@ export async function getRootCertClientCertAndKey(): Promise<MTLSCertAndPrivateK
     clientCertAndKey: { cert: clientCert, privateKey: clientKey }
   }
   return clientCertDicts[certDictKey]
+}
+
+export async function copyFromPod(sourcePath: string, localPath: string, podName: string, containerName: string) {
+  const command = ['tar', 'zcf', '-', sourcePath];
+  const writerStream = tar.extract(localPath);
+  const errStream = new WritableStreamBuffer();
+
+  try {
+    core.info(`copying to ${localPath} from ${sourcePath}`)
+    await new Promise<void>(async (resolve, reject) => {
+      try {
+        await k8sExec.exec(
+          namespace(),
+          podName,
+          containerName,
+          command,
+          writerStream,
+          errStream,
+          null,
+          false,
+          async () => {
+            if (errStream.size()) {
+              const errString = stringify(errStream.getContentsAsString())
+              core.debug(
+                `error copying to ${localPath} from ${sourcePath} in pod ${podName}: ${errString}`
+              )
+              reject(new Error(`Error from cpToPod - details: \n ${errString}`))
+            } else {
+              resolve()
+            }
+          }
+        )
+      } catch (error) {
+        const message = extractErrorMessageFromK8sError(error)
+        core.debug(
+          `error copying to ${localPath} from ${sourcePath} in pod ${podName}: ${message}`
+        )
+        reject(error)
+      }
+    })
+    core.debug('finished copying')
+  } catch (error) {
+    core.debug(
+      `error copying to ${localPath} from ${sourcePath} in pod ${podName}: ${error})}`
+    )
+  }
 }
 
 /**

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -909,8 +909,9 @@ export async function getRootCertClientCertAndKey(): Promise<MTLSCertAndPrivateK
   return clientCertDicts[certDictKey]
 }
 
-export async function copyFromPod(sourcePath: string, localPath: string, podName: string, containerName: string) {
-  const command = ['tar', 'cf', '-', '-C', path.dirname(sourcePath), path.basename(sourcePath)]
+// Copy from files from sourcePath
+export async function copyFromPod(sourcePathFolder: string, localPath: string, podName: string, containerName: string) {
+  const command = ['tar', 'cf', '-', '-C', sourcePathFolder, "."]
   const errStream = new WritableStreamBuffer()
 
   if (!fs.existsSync(localPath)) {
@@ -919,7 +920,7 @@ export async function copyFromPod(sourcePath: string, localPath: string, podName
   const extract = tar.extract(localPath)
 
   try {
-    core.info(`copying to ${localPath} from ${sourcePath}`)
+    core.info(`copying files from ${sourcePathFolder} to ${localPath}`)
     await new Promise<void>(async (resolve, reject) => {
       try {
         await k8sExec.exec(
@@ -935,7 +936,7 @@ export async function copyFromPod(sourcePath: string, localPath: string, podName
             if (errStream.size()) {
               const errString = stringify(errStream.getContentsAsString())
               core.debug(
-                `error 0 copying to ${localPath} from ${sourcePath} in pod ${podName}: ${errString}`
+                `error 0 copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${errString}`
               )
               reject(new Error(`Error from cpToPod - details: \n ${errString}`))
             } else {
@@ -946,7 +947,7 @@ export async function copyFromPod(sourcePath: string, localPath: string, podName
       } catch (error) {
         const message = extractErrorMessageFromK8sError(error)
         core.debug(
-          `error 1 copying to ${localPath} from ${sourcePath} in pod ${podName}: ${message}`
+          `error 1 copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${message}`
         )
         reject(error)
       }
@@ -955,7 +956,7 @@ export async function copyFromPod(sourcePath: string, localPath: string, podName
     await sleep(100000)
   } catch (error) {
     core.debug(
-      `error 2 copying to ${localPath} from ${sourcePath} in pod ${podName}: ${error})}`
+      `error 2 copying from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${error})}`
     )
   }
 }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -29,7 +29,7 @@ import {
 import { generateCerts, MTLSCertAndPrivateKey } from './certs'
 import { v4 as uuidv4 } from 'uuid'
 import * as fs from 'fs'
-import { join } from 'path'
+import * as path from 'path'
 
 const kc = new k8s.KubeConfig()
 
@@ -909,10 +909,9 @@ export async function getRootCertClientCertAndKey(): Promise<MTLSCertAndPrivateK
 }
 
 export async function copyFromPod(sourcePath: string, localPath: string, podName: string, containerName: string) {
-//  const command = ['tar', 'cf', '-', '-C', leadingDirectory, sourcePath];
-  const command = ['tar', 'cf', '-', sourcePath]
+  const command = ['tar', 'cf', '-', '-C', path.dirname(sourcePath), path.basename(sourcePath)]
   const errStream = new WritableStreamBuffer()
-  const writerStream = fs.createWriteStream(join(localPath, `tmp-${uuidv4().substring(0, 5)}.tar`));
+  const writerStream = fs.createWriteStream(path.join(localPath, `tmp-${uuidv4().substring(0, 5)}.tar`));
 
   if (!fs.existsSync(localPath)) {
     fs.mkdirSync(localPath, { recursive: true})

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -936,7 +936,7 @@ export async function copyFromPod(sourcePathFolder: string, localPath: string, p
             if (errStream.size()) {
               const errString = stringify(errStream.getContentsAsString())
               core.debug(
-                `error 0 copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${errString}`
+                `error copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${errString}`
               )
               reject(new Error(`Error from cpToPod - details: \n ${errString}`))
             } else {
@@ -947,16 +947,15 @@ export async function copyFromPod(sourcePathFolder: string, localPath: string, p
       } catch (error) {
         const message = extractErrorMessageFromK8sError(error)
         core.debug(
-          `error 1 copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${message}`
+          `error copying files from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${message}`
         )
         reject(error)
       }
     })
     core.info('finished copying ')
-    await sleep(100000)
   } catch (error) {
     core.debug(
-      `error 2 copying from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${error})}`
+      `error copying from ${sourcePathFolder} to ${localPath} in pod ${podName}: ${error})}`
     )
   }
 }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -909,7 +909,9 @@ export async function getRootCertClientCertAndKey(): Promise<MTLSCertAndPrivateK
   return clientCertDicts[certDictKey]
 }
 
-// Copy from files from sourcePath
+// Copy files from sourcePathFolder to localPath.
+// For example copyFromPod(/foo/bar, /bar, podName, containerName) will copy
+// all files in /foo/bar into /bar.
 export async function copyFromPod(sourcePathFolder: string, localPath: string, podName: string, containerName: string) {
   const command = ['tar', 'cf', '-', '-C', sourcePathFolder, "."]
   const errStream = new WritableStreamBuffer()
@@ -920,7 +922,7 @@ export async function copyFromPod(sourcePathFolder: string, localPath: string, p
   const extract = tar.extract(localPath)
 
   try {
-    core.info(`copying files from ${sourcePathFolder} to ${localPath}`)
+    core.debug(`copying files from ${sourcePathFolder} to ${localPath}`)
     await new Promise<void>(async (resolve, reject) => {
       try {
         await k8sExec.exec(

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -952,6 +952,12 @@ export async function copyFromPod(sourcePathFolder: string, localPath: string, p
         reject(error)
       }
     })
+    extract.on("error", err => {
+      core.debug(`Error extracting ${err}`)
+    })
+    extract.on("finish", () => {
+      core.debug("extract finished copying")
+    })
     core.info('finished copying ')
   } catch (error) {
     core.debug(

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -24,7 +24,7 @@ import {
   fixArgs,
   createScriptExecutorContainer,
   useScriptExecutor,
-  getNumberOfHost,
+  getNumberOfHost
 } from './utils'
 import { generateCerts, MTLSCertAndPrivateKey } from './certs'
 import { v4 as uuidv4 } from 'uuid'
@@ -910,12 +910,17 @@ export async function getRootCertClientCertAndKey(): Promise<MTLSCertAndPrivateK
 // Copy files from sourcePathFolder to localPath.
 // For example copyFromPod(/foo/bar, /bar, podName, containerName) will copy
 // all files in /foo/bar into /bar.
-export async function copyFromPod(sourcePathFolder: string, localPath: string, podName: string, containerName: string) {
-  const command = ['tar', 'cf', '-', '-C', sourcePathFolder, "."]
+export async function copyFromPod(
+  sourcePathFolder: string,
+  localPath: string,
+  podName: string,
+  containerName: string
+): Promise<void> {
+  const command = ['tar', 'cf', '-', '-C', sourcePathFolder, '.']
   const errStream = new WritableStreamBuffer()
 
   if (!fs.existsSync(localPath)) {
-    fs.mkdirSync(localPath, { recursive: true})
+    fs.mkdirSync(localPath, { recursive: true })
   }
   const extract = tar.extract(localPath)
 
@@ -940,13 +945,13 @@ export async function copyFromPod(sourcePathFolder: string, localPath: string, p
               )
               reject(new Error(`Error from cpToPod - details: \n ${errString}`))
             } else {
-              core.debug('wait for extracting to finish')
-              extract.on("error", err => {
-                core.debug(`Error extracting ${err}`)
-                reject()
+              core.debug('wait for extraction to finish')
+              extract.on('error', err => {
+                core.debug(`error extracting ${err}`)
+                reject(new Error(`error extracting ${err}`))
               })
-              extract.on("finish", () => {
-                core.debug(`Extract finished copying `)
+              extract.on('finish', () => {
+                core.debug(`extract finished copying `)
                 resolve()
               })
             }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -25,7 +25,6 @@ import {
   createScriptExecutorContainer,
   useScriptExecutor,
   getNumberOfHost,
-  sleep
 } from './utils'
 import { generateCerts, MTLSCertAndPrivateKey } from './certs'
 import { v4 as uuidv4 } from 'uuid'

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -907,8 +907,8 @@ export async function getRootCertClientCertAndKey(): Promise<MTLSCertAndPrivateK
   return clientCertDicts[certDictKey]
 }
 
-export async function copyFromPod(sourcePath: string, localPath: string, podName: string, containerName: string) {
-  const command = ['tar', 'zcf', '-', sourcePath];
+export async function copyFromPod(leadingDirectory: string, sourcePath: string, localPath: string, podName: string, containerName: string) {
+  const command = ['tar', 'zcf', '-', '-C', leadingDirectory, sourcePath];
   const writerStream = tar.extract(localPath);
   const errStream = new WritableStreamBuffer();
 
@@ -928,7 +928,7 @@ export async function copyFromPod(sourcePath: string, localPath: string, podName
           async () => {
             if (errStream.size()) {
               const errString = stringify(errStream.getContentsAsString())
-              core.debug(
+              core.info(
                 `error copying to ${localPath} from ${sourcePath} in pod ${podName}: ${errString}`
               )
               reject(new Error(`Error from cpToPod - details: \n ${errString}`))
@@ -939,15 +939,15 @@ export async function copyFromPod(sourcePath: string, localPath: string, podName
         )
       } catch (error) {
         const message = extractErrorMessageFromK8sError(error)
-        core.debug(
+        core.info(
           `error copying to ${localPath} from ${sourcePath} in pod ${podName}: ${message}`
         )
         reject(error)
       }
     })
-    core.debug('finished copying')
+    core.info('finished copying')
   } catch (error) {
-    core.debug(
+    core.info(
       `error copying to ${localPath} from ${sourcePath} in pod ${podName}: ${error})}`
     )
   }

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -921,7 +921,7 @@ export async function copyFromPod(sourcePathFolder: string, localPath: string, p
 
   try {
     core.info(`copying files from ${sourcePathFolder} to ${localPath}`)
-    const execPromise = new Promise<void>(async (resolve, reject) => {
+    await new Promise<void>(async (resolve, reject) => {
       try {
         await k8sExec.exec(
           namespace(),

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -29,7 +29,6 @@ import {
 import { generateCerts, MTLSCertAndPrivateKey } from './certs'
 import { v4 as uuidv4 } from 'uuid'
 import * as fs from 'fs'
-import * as path from 'path'
 
 const kc = new k8s.KubeConfig()
 

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -28,7 +28,8 @@ import {
 } from './utils'
 import { generateCerts, MTLSCertAndPrivateKey } from './certs'
 import { v4 as uuidv4 } from 'uuid'
-import { createWriteStream, readFileSync } from 'fs'
+import * as fs from 'fs'
+import { join } from 'path'
 
 const kc = new k8s.KubeConfig()
 
@@ -907,10 +908,16 @@ export async function getRootCertClientCertAndKey(): Promise<MTLSCertAndPrivateK
   return clientCertDicts[certDictKey]
 }
 
-export async function copyFromPod(leadingDirectory: string, sourcePath: string, localPath: string, podName: string, containerName: string) {
-  const command = ['tar', 'zcf', '-', '-C', leadingDirectory, sourcePath];
-  const writerStream = tar.extract(localPath);
-  const errStream = new WritableStreamBuffer();
+export async function copyFromPod(sourcePath: string, localPath: string, podName: string, containerName: string) {
+//  const command = ['tar', 'cf', '-', '-C', leadingDirectory, sourcePath];
+  const command = ['tar', 'cf', '-', sourcePath]
+  const errStream = new WritableStreamBuffer()
+  const writerStream = fs.createWriteStream(join(localPath, `tmp-${uuidv4().substring(0, 5)}.tar`));
+
+  if (!fs.existsSync(localPath)) {
+    fs.mkdirSync(localPath, { recursive: true})
+  }
+  const extract = tar.extract(localPath)
 
   try {
     core.info(`copying to ${localPath} from ${sourcePath}`)
@@ -921,15 +928,15 @@ export async function copyFromPod(leadingDirectory: string, sourcePath: string, 
           podName,
           containerName,
           command,
-          writerStream,
+          extract,
           errStream,
           null,
           false,
           async () => {
             if (errStream.size()) {
               const errString = stringify(errStream.getContentsAsString())
-              core.info(
-                `error copying to ${localPath} from ${sourcePath} in pod ${podName}: ${errString}`
+              core.debug(
+                `error 0 copying to ${localPath} from ${sourcePath} in pod ${podName}: ${errString}`
               )
               reject(new Error(`Error from cpToPod - details: \n ${errString}`))
             } else {
@@ -939,16 +946,16 @@ export async function copyFromPod(leadingDirectory: string, sourcePath: string, 
         )
       } catch (error) {
         const message = extractErrorMessageFromK8sError(error)
-        core.info(
-          `error copying to ${localPath} from ${sourcePath} in pod ${podName}: ${message}`
+        core.debug(
+          `error 1 copying to ${localPath} from ${sourcePath} in pod ${podName}: ${message}`
         )
         reject(error)
       }
     })
     core.info('finished copying')
   } catch (error) {
-    core.info(
-      `error copying to ${localPath} from ${sourcePath} in pod ${podName}: ${error})}`
+    core.debug(
+      `error 2 copying to ${localPath} from ${sourcePath} in pod ${podName}: ${error})}`
     )
   }
 }

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -391,9 +391,11 @@ export async function runScriptByGrpc(
       }
 
       if (response.has_output && outputStream) {
+        core.debug('writing output')
         outputStream.write(`${response.output}`)
       }
       if (response.has_error && errStream) {
+        core.debug('writing error')
         errStream.write(`${response.error}`)
       }
     })

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -387,14 +387,15 @@ export async function runScriptByGrpc(
       }
 
       if (response.has_output && streamOutputAndError) {
+        let trimOutput = response.output.trimStart()
         // For most workflow command, we can put the jobPrefix at the end.
         // TODO(quoct): Handle the group workflow command.
         const isGroupCmd =
-          response.output.startsWith('::group') ||
-          response.output.startsWith('::endgroup')
+        trimOutput.startsWith('::group') ||
+        trimOutput.startsWith('::endgroup')
         const shouldSwap =
           jobPrefix.length > 1 &&
-          response.output.startsWith('::') &&
+          trimOutput.startsWith('::') &&
           !isGroupCmd
 
           core.info('write output ' + shouldSwap)

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -391,15 +391,12 @@ export async function runScriptByGrpc(
         // For most workflow command, we can put the jobPrefix at the end.
         // TODO(quoct): Handle the group workflow command.
         const isGroupCmd =
-        trimOutput.startsWith('::group') ||
-        trimOutput.startsWith('::endgroup')
+          trimOutput.startsWith('::group') ||
+          trimOutput.startsWith('::endgroup')
         const shouldSwap =
-          jobPrefix.length > 1 &&
-          trimOutput.startsWith('::') &&
-          !isGroupCmd
+          jobPrefix.length > 1 && trimOutput.startsWith('::') && !isGroupCmd
 
-          core.info('write output ' + shouldSwap)
-          process.stdout.write(
+        process.stdout.write(
           shouldSwap
             ? `${response.output} (${jobPrefix})`
             : `(${jobPrefix}): ${response.output}`

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -312,7 +312,8 @@ export function useScriptExecutor(): boolean {
 }
 
 export function getNumberOfHost(): number {
-  return Number(process.env[ENV_NUMBER_OF_HOSTS]) || 1
+  return 1
+//  return Number(process.env[ENV_NUMBER_OF_HOSTS]) || 1
 }
 
 export enum PodPhase {

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -312,8 +312,7 @@ export function useScriptExecutor(): boolean {
 }
 
 export function getNumberOfHost(): number {
-  return 1
-//  return Number(process.env[ENV_NUMBER_OF_HOSTS]) || 1
+  return Number(process.env[ENV_NUMBER_OF_HOSTS]) || 1
 }
 
 export enum PodPhase {

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -396,11 +396,11 @@ export async function runScriptByGrpc(
           jobPrefix.length > 1 &&
           response.output.startsWith('::') &&
           !isGroupCmd
-        core.info("response output is " + response.output + " should swap is " + shouldSwap)
+
         process.stdout.write(
           shouldSwap
-            ? `${response.output}${jobPrefix}`
-            : `${jobPrefix}${response.output}`
+            ? `${response.output} (${jobPrefix})`
+            : `(${jobPrefix}): ${response.output}`
         )
       }
       if (response.has_error && streamOutputAndError) {

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -397,7 +397,7 @@ export async function runScriptByGrpc(
       // Half a second wait in case the data event with the exit code did not get triggered yet.
       await sleep(500)
       if (streamOutputAndError) {
-        process.stdout.write(`${jobPrefix}Job exit code is ${exitCode}.`)
+        process.stdout.write(`${jobPrefix}Job exit code is ${exitCode}.\n`)
       }
       if (exitCode === 0) {
         resolve()

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -397,13 +397,15 @@ export async function runScriptByGrpc(
           response.output.startsWith('::') &&
           !isGroupCmd
 
-        process.stdout.write(
+          core.info('write output ' + shouldSwap)
+          process.stdout.write(
           shouldSwap
             ? `${response.output} (${jobPrefix})`
             : `(${jobPrefix}): ${response.output}`
         )
       }
       if (response.has_error && streamOutputAndError) {
+        core.info('write error')
         process.stderr.write(`${jobPrefix}${response.error}`)
       }
     })

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -385,8 +385,23 @@ export async function runScriptByGrpc(
       if (response.has_code) {
         exitCode = response.code
       }
+
       if (response.has_output && streamOutputAndError) {
-        process.stdout.write(`${jobPrefix}${response.output}`)
+        // For most workflow command, we can put the jobPrefix at the end.
+        // TODO(quoct): Handle the group workflow command.
+        const isGroupCmd =
+          response.output.startsWith('::group') ||
+          response.output.startsWith('::endgroup')
+        const shouldSwap =
+          jobPrefix.length > 1 &&
+          response.output.startsWith('::') &&
+          !isGroupCmd
+
+        process.stdout.write(
+          shouldSwap
+            ? `${response.output}${jobPrefix}`
+            : `${jobPrefix}${response.output}`
+        )
       }
       if (response.has_error && streamOutputAndError) {
         process.stderr.write(`${jobPrefix}${response.error}`)

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -396,7 +396,7 @@ export async function runScriptByGrpc(
           jobPrefix.length > 1 &&
           response.output.startsWith('::') &&
           !isGroupCmd
-
+        core.info("response output is " + response.output + " should swap is " + shouldSwap)
         process.stdout.write(
           shouldSwap
             ? `${response.output}${jobPrefix}`

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -344,7 +344,7 @@ export async function sleep(ms: number): Promise<void> {
 /**
  * Invoke GRPC server at ip_address:grpc_port to run a command.
  * Stream output and error from the command to the console by default.
- * Also appends a jobPrefix string to the output if provided.
+ * Also appends a jobSuffix string to the output if provided.
  */
 export async function runScriptByGrpc(
   command: string,
@@ -354,7 +354,7 @@ export async function runScriptByGrpc(
   ip: string,
   grpc_port = 50051,
   streamOutputAndError = true,
-  jobPrefix = ''
+  jobSuffix = ''
 ): Promise<void> {
   const client = new script_executor.ScriptExecutorClient(
     `${ip}:${grpc_port}`,
@@ -374,7 +374,7 @@ export async function runScriptByGrpc(
     }
   )
 
-  core.debug(`executing script ${command} for job ${jobPrefix}`)
+  core.debug(`executing script ${command} for job ${jobSuffix}`)
   // TODO(quoct): Add logic to prevent duplicate execution using the `id` field.
   const call = client.ExecuteScript(
     new script_executor.ScriptRequest({ script: command })
@@ -387,24 +387,10 @@ export async function runScriptByGrpc(
       }
 
       if (response.has_output && streamOutputAndError) {
-        let trimOutput = response.output.trimStart()
-        // For most workflow command, we can put the jobPrefix at the end.
-        // TODO(quoct): Handle the group workflow command.
-        const isGroupCmd =
-          trimOutput.startsWith('::group') ||
-          trimOutput.startsWith('::endgroup')
-        const shouldSwap =
-          jobPrefix.length > 1 && trimOutput.startsWith('::') && !isGroupCmd
-
-        process.stdout.write(
-          shouldSwap
-            ? `${response.output} (${jobPrefix})`
-            : `(${jobPrefix}): ${response.output}`
-        )
+        process.stdout.write(`${response.output} (${jobSuffix})`)
       }
       if (response.has_error && streamOutputAndError) {
-        core.info('write error')
-        process.stderr.write(`${jobPrefix}${response.error}`)
+        process.stderr.write(`${response.error} (${jobSuffix})`)
       }
     })
 
@@ -412,17 +398,19 @@ export async function runScriptByGrpc(
       // Half a second wait in case the data event with the exit code did not get triggered yet.
       await sleep(500)
       if (streamOutputAndError) {
-        process.stdout.write(`${jobPrefix}Job exit code is ${exitCode}.\n`)
+        process.stdout.write(`Job exit code is ${exitCode} (${jobSuffix}).\n`)
       }
       if (exitCode === 0) {
         resolve()
       } else {
-        reject(new Error(`${jobPrefix}Job failed with exit code ${exitCode}.`))
+        reject(
+          new Error(`Job failed with exit code ${exitCode} (${jobSuffix}).`)
+        )
       }
     })
 
     call.on('error', (err: any) => {
-      const errorMessage = `${jobPrefix}Error execing ${command}: ${err}`
+      const errorMessage = `Error execing (${jobSuffix}) ${command}: ${err}`
       if (streamOutputAndError) {
         process.stdout.write(errorMessage)
       }

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -9,7 +9,10 @@ import * as path from 'path'
 import { Mount } from 'hooklib'
 import { v1 as uuidv4 } from 'uuid'
 import { POD_VOLUME_NAME } from './index'
-import { CONTAINER_EXTENSION_PREFIX } from '../hooks/constants'
+import {
+  CONTAINER_EXTENSION_PREFIX,
+  GRPC_SCRIPT_EXECUTOR_PORT
+} from '../hooks/constants'
 import { script_executor } from './script_executor'
 
 export const DEFAULT_CONTAINER_ENTRY_POINT_ARGS = [`-f`, `/dev/null`]
@@ -352,9 +355,9 @@ export async function runScriptByGrpc(
   clientCert: string,
   clientKey: string,
   ip: string,
-  grpc_port = 50051,
-  streamOutputAndError = true,
-  jobSuffix = ''
+  grpc_port = GRPC_SCRIPT_EXECUTOR_PORT,
+  outputStream: NodeJS.WriteStream | undefined = process.stdout, // eslint-disable-line no-undef
+  errStream: NodeJS.WriteStream | undefined = process.stderr // eslint-disable-line no-undef
 ): Promise<void> {
   const client = new script_executor.ScriptExecutorClient(
     `${ip}:${grpc_port}`,
@@ -374,7 +377,7 @@ export async function runScriptByGrpc(
     }
   )
 
-  core.debug(`executing script ${command} for job ${jobSuffix}`)
+  core.debug(`executing script ${command}`)
   // TODO(quoct): Add logic to prevent duplicate execution using the `id` field.
   const call = client.ExecuteScript(
     new script_executor.ScriptRequest({ script: command })
@@ -386,33 +389,31 @@ export async function runScriptByGrpc(
         exitCode = response.code
       }
 
-      if (response.has_output && streamOutputAndError) {
-        process.stdout.write(`${response.output} (${jobSuffix})`)
+      if (response.has_output && outputStream) {
+        outputStream.write(`${response.output}`)
       }
-      if (response.has_error && streamOutputAndError) {
-        process.stderr.write(`${response.error} (${jobSuffix})`)
+      if (response.has_error && errStream) {
+        errStream.write(`${response.error}`)
       }
     })
 
     call.on('end', async () => {
       // Half a second wait in case the data event with the exit code did not get triggered yet.
       await sleep(500)
-      if (streamOutputAndError) {
-        process.stdout.write(`Job exit code is ${exitCode} (${jobSuffix}).\n`)
+      if (outputStream) {
+        outputStream.write(`Job exit code is ${exitCode}.\n`)
       }
       if (exitCode === 0) {
         resolve()
       } else {
-        reject(
-          new Error(`Job failed with exit code ${exitCode} (${jobSuffix}).`)
-        )
+        reject(new Error(`Job failed with exit code ${exitCode}.`))
       }
     })
 
     call.on('error', (err: any) => {
-      const errorMessage = `Error execing (${jobSuffix}) ${command}: ${err}`
-      if (streamOutputAndError) {
-        process.stdout.write(errorMessage)
+      const errorMessage = `Error execing ${command}: ${err}`
+      if (errStream) {
+        errStream.write(errorMessage)
       }
       reject(new Error(errorMessage))
     })

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -14,6 +14,7 @@ import {
   GRPC_SCRIPT_EXECUTOR_PORT
 } from '../hooks/constants'
 import { script_executor } from './script_executor'
+import { Writable } from 'stream'
 
 export const DEFAULT_CONTAINER_ENTRY_POINT_ARGS = [`-f`, `/dev/null`]
 export const DEFAULT_CONTAINER_ENTRY_POINT = 'tail'
@@ -356,8 +357,8 @@ export async function runScriptByGrpc(
   clientKey: string,
   ip: string,
   grpc_port = GRPC_SCRIPT_EXECUTOR_PORT,
-  outputStream: NodeJS.WriteStream | undefined = process.stdout, // eslint-disable-line no-undef
-  errStream: NodeJS.WriteStream | undefined = process.stderr // eslint-disable-line no-undef
+  outputStream: Writable | undefined = process.stdout,
+  errStream: Writable | undefined = process.stderr
 ): Promise<void> {
   const client = new script_executor.ScriptExecutorClient(
     `${ip}:${grpc_port}`,

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -391,11 +391,9 @@ export async function runScriptByGrpc(
       }
 
       if (response.has_output && outputStream) {
-        core.debug('writing output')
         outputStream.write(`${response.output}`)
       }
       if (response.has_error && errStream) {
-        core.debug('writing error')
         errStream.write(`${response.error}`)
       }
     })
@@ -404,12 +402,14 @@ export async function runScriptByGrpc(
       // Half a second wait in case the data event with the exit code did not get triggered yet.
       await sleep(500)
       if (outputStream) {
-        outputStream.write(`Job exit code is ${exitCode}.\n`)
+        core.debug(`Command ${command} exit code is ${exitCode}.\n`)
       }
       if (exitCode === 0) {
         resolve()
       } else {
-        reject(new Error(`Job failed with exit code ${exitCode}.`))
+        reject(
+          new Error(`Command ${command} failed with exit code ${exitCode}.`)
+        )
       }
     })
 

--- a/packages/k8s/tests/e2e-test.ts
+++ b/packages/k8s/tests/e2e-test.ts
@@ -134,7 +134,8 @@ describe('script-executor', () => {
           certs.caCertAndkey.cert,
           certs.clientCertAndKey.cert,
           certs.clientCertAndKey.privateKey,
-          'localhost'
+          'localhost',
+          50051
         )
       ).resolves.not.toThrow()
     } finally {


### PR DESCRIPTION
- Add a helper function to copy files from a folder in a pod to the local machine.
- Use the helper function to copy file commands from workflow to runner pods.
- These are used by various actions to set things up and are inspected by the runners.