### PR TITLE
Add ability to parse `--entrypoint` from `createOptions` passed to the service containers

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -35,7 +35,8 @@ import {
   SCRIPT_EXECUTOR_ENTRY_POINT_ARGS,
   getNumberOfHost,
   sleep,
-  generateServicesName
+  generateServicesName,
+  getEntryPointAndArgs
 } from '../k8s/utils'
 import {
   CONTAINER_EXTENSION_PREFIX,
@@ -76,7 +77,8 @@ export async function prepareJob(
         service,
         generateContainerName(service.image),
         false,
-        extension
+        extension,
+        service.createOptions
       )
     })
   }
@@ -285,7 +287,8 @@ export function createContainerSpec(
   container: JobContainerInfo,
   name: string,
   jobContainer = false,
-  extension?: k8s.V1PodTemplateSpec
+  extension?: k8s.V1PodTemplateSpec,
+  createOptions?: string
 ): k8s.V1Container {
   if (!container.entryPoint && jobContainer) {
     container.entryPoint = DEFAULT_CONTAINER_ENTRY_POINT
@@ -302,6 +305,20 @@ export function createContainerSpec(
       ]
         ? process.env['ACTIONS_RUNNER_SCRIPT_EXECUTOR_ARGS'].split(' ')
         : SCRIPT_EXECUTOR_ENTRY_POINT_ARGS
+    }
+  }
+
+  if (!jobContainer && createOptions && createOptions?.length > 0) {
+    core.debug(
+      `overriding service container ${JSON.stringify(
+        container
+      )} with createOptions ${createOptions}`
+    )
+    const entryPointAndArgs = getEntryPointAndArgs(createOptions)
+    if (entryPointAndArgs.length > 1) {
+      core.debug(`overriding container entry points with ${entryPointAndArgs}`)
+      container.entryPoint = entryPointAndArgs[0]
+      container.entryPointArgs = entryPointAndArgs.slice(1)
     }
   }
 

--- a/packages/k8s/src/k8s/utils.ts
+++ b/packages/k8s/src/k8s/utils.ts
@@ -465,3 +465,16 @@ export function createScriptExecutorContainer(
   initContainer.volumeMounts.push(scriptExecutorVolumeMount)
   return initContainer
 }
+
+const entrypointRegex = /--entrypoint=\[(.*?)\]/
+
+export function getEntryPointAndArgs(createOptions: string): string[] {
+  const match = createOptions.match(entrypointRegex)
+
+  if (!match || match[1] === undefined) {
+    core.debug(`no match for createoptions ${createOptions}`)
+    return []
+  }
+
+  return match[1].split(',').map(item => item.trim())
+}

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -385,7 +385,7 @@ describe('k8s utils', () => {
       expect(getEntryPointAndArgs(`--entrypoint=["/foo"]`)).toEqual(['"/foo"'])
       expect(
         getEntryPointAndArgs(`--entrypoint=["/foo", "--a", "--b"]`)
-      ).toEqual(['"/foo"', '--a', '--b'])
+      ).toEqual(['"/foo"', '"--a"', '"--b"'])
     })
   })
 

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -12,7 +12,8 @@ import {
   createScriptExecutorContainer,
   getNumberOfHost,
   ENV_NUMBER_OF_HOSTS,
-  generateServicesName
+  generateServicesName,
+  getEntryPointAndArgs
 } from '../src/k8s/utils'
 import * as k8s from '@kubernetes/client-node'
 import { TestHelper } from './test-setup'
@@ -375,6 +376,16 @@ describe('k8s utils', () => {
         { image: 'foo', name: 'foo' },
         { image: 'foo', name: 'foo-1' }
       ])
+    })
+  })
+
+  describe('getEntryPointAndArgs', () => {
+    it('should return correct entrypoint and argument', () => {
+      expect(getEntryPointAndArgs(`--blah`)).toEqual([])
+      expect(getEntryPointAndArgs(`--entrypoint=["/foo"]`)).toEqual(['/foo'])
+      expect(
+        getEntryPointAndArgs(`--entrypoint=["/foo", "--a", "--b"]`)
+      ).toEqual(['/foo', '--a', '--b'])
     })
   })
 

--- a/packages/k8s/tests/k8s-utils-test.ts
+++ b/packages/k8s/tests/k8s-utils-test.ts
@@ -382,10 +382,10 @@ describe('k8s utils', () => {
   describe('getEntryPointAndArgs', () => {
     it('should return correct entrypoint and argument', () => {
       expect(getEntryPointAndArgs(`--blah`)).toEqual([])
-      expect(getEntryPointAndArgs(`--entrypoint=["/foo"]`)).toEqual(['/foo'])
+      expect(getEntryPointAndArgs(`--entrypoint=["/foo"]`)).toEqual(['"/foo"'])
       expect(
         getEntryPointAndArgs(`--entrypoint=["/foo", "--a", "--b"]`)
-      ).toEqual(['/foo', '--a', '--b'])
+      ).toEqual(['"/foo"', '--a', '--b'])
     })
   })
 


### PR DESCRIPTION
This will let users specify entrypoint for the service containers. An example:
```
    services:
      resource_manager:
        image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest
        options:
          --entrypoint=[/usr/pathways/run/cloud_pathways_server_sanitized, --server_port=29001]
```