### PR TITLE
Add retry logic when creating headless service

### DIFF
--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -16,11 +16,12 @@ import {
   prunePods,
   waitForPodPhases,
   getPrepareJobTimeoutSeconds,
-  createHeadlessService,
   extractErrorMessageFromK8sError,
   createJobSet,
   createPodSpec,
-  getPodsFromJobSet
+  getPodsFromJobSet,
+  BackOffManager,
+  createHeadlessServiceWithRetry
 } from '../k8s'
 import {
   containerVolumes,
@@ -43,6 +44,7 @@ import {
 import {
   CONTAINER_EXTENSION_PREFIX,
   getJobSetName,
+  getServiceName,
   JOB_CONTAINER_NAME
 } from './constants'
 
@@ -138,7 +140,7 @@ export async function prepareJob(
 
   if (useScriptExecutor() && getNumberOfHost() === 1) {
     core.debug(`Creating headless service`)
-    await createHeadlessService()
+    await createHeadlessServiceWithRetry()
   }
 
   generateResponseFile(responseFile, args, createdPod, isAlpine)

--- a/packages/k8s/src/hooks/prepare-job.ts
+++ b/packages/k8s/src/hooks/prepare-job.ts
@@ -20,7 +20,6 @@ import {
   createJobSet,
   createPodSpec,
   getPodsFromJobSet,
-  BackOffManager,
   createHeadlessServiceWithRetry
 } from '../k8s'
 import {
@@ -44,7 +43,6 @@ import {
 import {
   CONTAINER_EXTENSION_PREFIX,
   getJobSetName,
-  getServiceName,
   JOB_CONTAINER_NAME
 } from './constants'
 

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -626,6 +626,22 @@ export async function prunePods(): Promise<void> {
   )
 }
 
+export async function createHeadlessServiceWithRetry() {
+  const backOffmanager = new BackOffManager(60)
+  while (true) {
+    try {
+      await createHeadlessService()
+      return
+    } catch (err) {
+      const message = extractErrorMessageFromK8sError(err)
+      core.warning(
+        `failed to create headless service ${getServiceName} with error ${message}. Retrying`
+      )
+      await backOffmanager.backOff()
+    }
+  }
+}
+
 export async function pruneServices(): Promise<void> {
   const labelSelector = new RunnerInstanceLabel().toString()
   core.debug(`pruning services with labels ${labelSelector}`)

--- a/packages/k8s/src/k8s/index.ts
+++ b/packages/k8s/src/k8s/index.ts
@@ -626,7 +626,7 @@ export async function prunePods(): Promise<void> {
   )
 }
 
-export async function createHeadlessServiceWithRetry() {
+export async function createHeadlessServiceWithRetry(): Promise<void> {
   const backOffmanager = new BackOffManager(60)
   while (true) {
     try {


### PR DESCRIPTION
We will attempt to create the headless service with backoff logic within 60 seconds.